### PR TITLE
[android] updated notification frostwire icon

### DIFF
--- a/android/apollo/src/com/andrew/apollo/NotificationHelper.java
+++ b/android/apollo/src/com/andrew/apollo/NotificationHelper.java
@@ -118,7 +118,7 @@ public class NotificationHelper {
     }
 
     private int getNotificationIcon() {
-        return Build.VERSION.SDK_INT >= 21 ? R.drawable.frostwire_notification_flat : R.drawable.frostwire_notification;
+        return R.drawable.frostwire_notification_flat;
     }
 
     /**

--- a/android/changelog.txt
+++ b/android/changelog.txt
@@ -1,3 +1,9 @@
+FrostWire 1.6.6 - NOVEMBER/11/2015
+ - Fixes YouTube search.
+ - New permanent notification lets you know FrostWire is running, how much bandwidth
+   it's using and whether or not your connection is encrypted with a VPN to protect
+   your fundamental human right to privacy.
+
 FrostWire 1.6.5 - OCTOBER/28/2015
  - Fixes bug where search results that have finished didn't refresh
    user interface and users would think FrostWire was searching forever.

--- a/android/src/com/frostwire/android/gui/services/EngineService.java
+++ b/android/src/com/frostwire/android/gui/services/EngineService.java
@@ -286,7 +286,6 @@ public class EngineService extends Service implements IEngineService {
     }
 
     private int getNotificationIcon() {
-        // return Build.VERSION.SDK_INT >= 21 ? R.drawable.frostwire_notification_flat : R.drawable.frostwire_notification_flat;
         return R.drawable.frostwire_notification_flat;
     }
 

--- a/android/src/com/frostwire/android/gui/services/EngineService.java
+++ b/android/src/com/frostwire/android/gui/services/EngineService.java
@@ -219,7 +219,7 @@ public class EngineService extends Service implements IEngineService {
 
 
         Notification notification = new NotificationCompat.Builder(context).
-                setSmallIcon(R.drawable.app_icon).
+                setSmallIcon(R.drawable.frostwire_notification_flat).
                 setContentIntent(showFrostWireIntent).
                 setContent(remoteViews).
                 build();
@@ -286,7 +286,8 @@ public class EngineService extends Service implements IEngineService {
     }
 
     private int getNotificationIcon() {
-        return Build.VERSION.SDK_INT >= 21 ? R.drawable.frostwire_notification_flat : R.drawable.frostwire_notification;
+        // return Build.VERSION.SDK_INT >= 21 ? R.drawable.frostwire_notification_flat : R.drawable.frostwire_notification_flat;
+        return R.drawable.frostwire_notification_flat;
     }
 
     private static long[] buildVenezuelanVibe() {


### PR DESCRIPTION
So the reason that the FrostWire notification icon looked like a nontransparent white ball is that starting in Android Lollipop all the icons in status bar are required to be white (although at times apps will hack this to use their colored version). And we were using our colored version without any modifications so that android was paining it white. 

I think Alden did that on purpose as it was causing some problems on lollipop, however now everything seems to be working fine after the recent updates to android app. Tested it on lollipop, marshmallow and api 16 emulator. 