### PR TITLE
[android] Sleep 1 more second, make sure BTEngine is stopped.

### DIFF
--- a/android/src/com/frostwire/android/gui/services/EngineService.java
+++ b/android/src/com/frostwire/android/gui/services/EngineService.java
@@ -116,7 +116,7 @@ public class EngineService extends Service implements IEngineService {
             @Override
             public void run() {
                 try {
-                    Thread.sleep(1000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     // ignore
                 }


### PR DESCRIPTION
@aldenml I couldn't replicate the issue with my phone. But I suppose when it happens it must be some sort of syncrhonization issue with the Service's onDestroy method.

My guess is that the process is killed before the Bittorrent session can finish it's `abort()` procedure.

Therefore I propose this patch to have that last thread sleep for one more second.

If not, maybe a better patch would be to somehow get a valid confirmation from the bittorrent session that it's actually been aborted all the way, and then we can continue to shutdown.