### PR TITLE
[common, desktop] fix #10

### DIFF
--- a/common/src/main/java/com/frostwire/search/archiveorg/ArchiveorgItem.java
+++ b/common/src/main/java/com/frostwire/search/archiveorg/ArchiveorgItem.java
@@ -39,7 +39,6 @@ public class ArchiveorgItem {
     public int num_reviews;
     public float avg_rating;
     public String identifier;
-    public List<String> subject;
     public List<String> format;
     public List<String> collection;
 }

--- a/common/src/main/java/com/frostwire/search/archiveorg/ArchiveorgSearchPerformer.java
+++ b/common/src/main/java/com/frostwire/search/archiveorg/ArchiveorgSearchPerformer.java
@@ -48,7 +48,7 @@ public class ArchiveorgSearchPerformer extends CrawlPagedWebSearchPerformer<Arch
                 + getDomainName()
                 + "/advancedsearch.php?q="
                 + encodedKeywords
-                + "&fl[]=avg_rating&fl[]=call_number&fl[]=collection&fl[]=contributor&fl[]=coverage&fl[]=creator&fl[]=date&fl[]=description&fl[]=downloads&fl[]=foldoutcount&fl[]=format&fl[]=headerImage&fl[]=identifier&fl[]=imagecount&fl[]=language&fl[]=licenseurl&fl[]=mediatype&fl[]=month&fl[]=num_reviews&fl[]=oai_updatedate&fl[]=publicdate&fl[]=publisher&fl[]=rights&fl[]=scanningcentre&fl[]=source&fl[]=subject&fl[]=title&fl[]=type&fl[]=volume&fl[]=week&fl[]=year&rows=50&page=1&indent=yes&output=json";
+                + "&fl[]=avg_rating&fl[]=call_number&fl[]=collection&fl[]=contributor&fl[]=coverage&fl[]=creator&fl[]=date&fl[]=description&fl[]=downloads&fl[]=foldoutcount&fl[]=format&fl[]=headerImage&fl[]=identifier&fl[]=imagecount&fl[]=language&fl[]=licenseurl&fl[]=mediatype&fl[]=month&fl[]=num_reviews&fl[]=oai_updatedate&fl[]=publicdate&fl[]=publisher&fl[]=rights&fl[]=scanningcentre&fl[]=source&fl[]=title&fl[]=type&fl[]=volume&fl[]=week&fl[]=year&rows=50&page=1&indent=yes&output=json";
         //sort[]=downloads+desc&sort[]=createdate+desc
         //sort[]=avg_rating+desc&
     }


### PR DESCRIPTION
#10 Archive.org return 'subject' in two different types, in one case String, in another as Array. Field Subject not uses. so I just deleted it.

and seriously for this $ 15? generous reward for such job.