### PR TITLE
[android] changed the default page to Last Added in My Music

### DIFF
--- a/android/apollo/src/com/andrew/apollo/utils/PreferenceUtils.java
+++ b/android/apollo/src/com/andrew/apollo/utils/PreferenceUtils.java
@@ -34,7 +34,7 @@ import com.andrew.apollo.ui.fragments.profile.ArtistSongFragment;
 public final class PreferenceUtils {
 
     /* Default start page (Artist page) */
-    public static final int DEFFAULT_PAGE = 2;
+    public static final int DEFFAULT_PAGE = 0;
 
     /* Saves the last page the pager was on in {@link MusicBrowserPhoneFragment} */
     public static final String START_PAGE = "start_page";


### PR DESCRIPTION
This works just fine if you want the Last Added to be the first tab when you open My Music for the first time. See my further comment on #51 if you think the Recent tab should be also a default page in My Music depending if you played one of your songs first without downloading. 