### PR TITLE
Android permanent notification deamon

### DIFF
--- a/android/src/com/frostwire/android/gui/NotificationUpdateDemon.java
+++ b/android/src/com/frostwire/android/gui/NotificationUpdateDemon.java
@@ -1,0 +1,137 @@
+package com.frostwire.android.gui;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.app.NotificationCompat;
+import android.widget.RemoteViews;
+
+import com.frostwire.android.R;
+import com.frostwire.android.core.ConfigurationManager;
+import com.frostwire.android.core.Constants;
+import com.frostwire.android.gui.activities.MainActivity;
+import com.frostwire.android.gui.services.EngineService;
+import com.frostwire.android.gui.transfers.TransferManager;
+import com.frostwire.android.gui.util.UIUtils;
+import com.frostwire.android.gui.views.TimerObserver;
+import com.frostwire.android.gui.views.TimerService;
+import com.frostwire.android.gui.views.TimerSubscription;
+import com.frostwire.logging.Logger;
+
+public class NotificationUpdateDemon implements TimerObserver{
+
+    private static final Logger LOG = Logger.getLogger(NotificationUpdateDemon.class);
+    private static final int FROSTWIRE_STATUS_NOTIFICATION_UPDATE_INTERVAL_IN_SECS = 5;
+
+    private Context mParentContext;
+    private TimerSubscription mTimerSubscription;
+
+    public NotificationUpdateDemon(Context parentContext) {
+        LOG.debug("Creating permanent notification demon");
+        mParentContext = parentContext;
+    }
+
+    public void start() {
+        LOG.debug("Starting permanent notification demon");
+        if(mTimerSubscription != null) {
+            LOG.debug("Stopping before (re)starting permanent notification demon");
+            mTimerSubscription.unsubscribe();
+        }
+        mTimerSubscription = TimerService.subscribe(this,FROSTWIRE_STATUS_NOTIFICATION_UPDATE_INTERVAL_IN_SECS);
+    }
+
+    public void stop() {
+        LOG.debug("Stopping permanent notification demon");
+        mTimerSubscription.unsubscribe();
+    }
+
+    private void updatePermanentStatusNotification() {
+
+        if (!ConfigurationManager.instance().getBoolean(Constants.PREF_KEY_GUI_ENABLE_PERMANENT_STATUS_NOTIFICATION)) {
+            return;
+        }
+
+        //  format strings
+        String sDown = UIUtils.rate2speed(TransferManager.instance().getDownloadsBandwidth() / 1024);
+        String sUp = UIUtils.rate2speed(TransferManager.instance().getUploadsBandwidth() / 1024);
+
+        // number of uploads (seeding) and downloads
+        int downloads = TransferManager.instance().getActiveDownloads();
+        int uploads = TransferManager.instance().getActiveUploads();
+
+        RemoteViews remoteViews = new RemoteViews(mParentContext.getPackageName(),
+                R.layout.view_permanent_status_notification);
+
+        PendingIntent showFrostWireIntent = createShowFrostwireIntent();
+//      PendingIntent showVPNIntent = createShowVPNIntent();
+        PendingIntent shutdownIntent = createShutdownIntent();
+
+
+        // VPN status
+//        remoteViews.setImageViewResource(R.id.view_permanent_status_vpn_icon, isVPNactive ?
+//                R.drawable.notification_shutdown : R.drawable.notification_shutdown);
+//        remoteViews.setOnClickPendingIntent(R.id.view_permanent_status_vpn_icon, showVPNIntent);
+
+
+        // Click on shutdown image button.
+        remoteViews.setOnClickPendingIntent(R.id.view_permanent_status_shutdown, shutdownIntent);
+
+        // Click on title takes to transfers.
+        remoteViews.setOnClickPendingIntent(R.id.view_permanent_status_text_title, showFrostWireIntent);
+
+        // Transfers status.
+        remoteViews.setTextViewText(R.id.view_permanent_status_text_downloads, downloads + " @ " + sDown);
+        remoteViews.setTextViewText(R.id.view_permanent_status_text_uploads, uploads + " @ " + sUp);
+
+        Notification notification = new NotificationCompat.Builder(mParentContext).
+                setSmallIcon(R.drawable.frostwire_notification_flat).
+                setContentIntent(showFrostWireIntent).
+                setContent(remoteViews).
+                build();
+        notification.flags |= Notification.FLAG_NO_CLEAR;
+
+        final NotificationManager notificationManager = (NotificationManager) mParentContext.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (notificationManager != null) {
+            notificationManager.notify(EngineService.FROSTWIRE_STATUS_NOTIFICATION, notification);
+        }
+    }
+
+    private PendingIntent createShowFrostwireIntent(){
+        return PendingIntent.getActivity(mParentContext,
+                0,
+                new Intent(mParentContext,
+                        MainActivity.class).
+                        setAction(Constants.ACTION_SHOW_TRANSFERS).
+                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK),
+                0);
+    }
+
+    private PendingIntent createShutdownIntent(){
+        return PendingIntent.getActivity(mParentContext,
+                1,
+                new Intent(mParentContext,
+                        MainActivity.class).
+                        setAction(Constants.ACTION_REQUEST_SHUTDOWN).
+                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK),
+                0);
+    }
+
+//    private PendingIntent createShowVPNIntent(){
+//        return PendingIntent.getActivity(mParentContext,
+//                1,
+//                new Intent(mParentContext,
+//                        VPNStatusDetailActivity.class).
+//                        setAction(isVPNactive ?
+//                                Constants.ACTION_SHOW_VPN_STATUS_PROTECTED :
+//                                Constants.ACTION_SHOW_VPN_STATUS_UNPROTECTED).
+//                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK),
+//                0);
+//    }
+
+    @Override
+    public void onTime() {
+        updatePermanentStatusNotification();
+    }
+}

--- a/android/src/com/frostwire/android/gui/activities/MainActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/MainActivity.java
@@ -45,6 +45,7 @@ import com.frostwire.android.R;
 import com.frostwire.android.StoragePicker;
 import com.frostwire.android.core.ConfigurationManager;
 import com.frostwire.android.core.Constants;
+import com.frostwire.android.gui.NotificationUpdateDemon;
 import com.frostwire.android.gui.SoftwareUpdater;
 import com.frostwire.android.gui.SoftwareUpdater.ConfigurationUpdateListener;
 import com.frostwire.android.gui.activities.internal.MainController;

--- a/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
@@ -44,7 +44,6 @@ import com.frostwire.android.gui.dialogs.HandpickedTorrentDownloadDialogOnFetch;
 import com.frostwire.android.gui.dialogs.MenuDialog;
 import com.frostwire.android.gui.dialogs.MenuDialog.MenuItem;
 import com.frostwire.android.gui.services.Engine;
-import com.frostwire.android.gui.services.EngineService;
 import com.frostwire.android.gui.tasks.DownloadSoundcloudFromUrlTask;
 import com.frostwire.android.gui.transfers.TransferManager;
 import com.frostwire.android.gui.util.SwipeDetector;
@@ -61,7 +60,6 @@ import com.frostwire.util.Ref;
 import com.frostwire.util.StringUtils;
 
 import java.io.File;
-import java.lang.ref.WeakReference;
 import java.util.*;
 
 /**
@@ -71,7 +69,8 @@ import java.util.*;
 public class TransfersFragment extends AbstractFragment implements TimerObserver, MainFragment, OnDialogClickListener, SwipeListener {
     private static final Logger LOG = Logger.getLogger(TransfersFragment.class);
     private static final String SELECTED_STATUS_STATE_KEY = "selected_status";
-    private static final int FROSTWIRE_STATUS_NOTIFICATION_UPDATE_INTERVAL_IN_SECS = 5;
+    private static final int UI_UPDATE_INTERVAL_IN_SECS = 2;
+    private static final int DHT_STATUS_UPDATE_INTERVAL_IN_SECS = 10;
     private final Comparator<Transfer> transferComparator;
     private final ButtonAddTransferListener buttonAddTransferListener;
     private final ButtonMenuListener buttonMenuListener;
@@ -87,7 +86,7 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
     private TransferListAdapter adapter;
     private TransferStatus selectedStatus;
     private TimerSubscription subscription;
-    private int androidNotificationUpdateTick;
+    private int delayedDHTUpdateTimeElapsed;
     private boolean isVPNactive;
     private static boolean firstTimeShown = true;
     private Handler vpnRichToastHandler;
@@ -169,7 +168,7 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
         int downloads = TransferManager.instance().getActiveDownloads();
         int uploads = TransferManager.instance().getActiveUploads();
 
-        updatePermanentStatusNotification(sDown, sUp, downloads, uploads);
+        delayedDHTCheck();
         updateStatusBar(sDown, sUp, downloads, uploads);
     }
 
@@ -179,19 +178,14 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
         updateVPNButtonIfStatusChanged(NetworkManager.instance().isTunnelUp());
     }
 
-    private void updatePermanentStatusNotification(String sDown, String sUp, int downloads, int uploads) {
-        if (++androidNotificationUpdateTick >= FROSTWIRE_STATUS_NOTIFICATION_UPDATE_INTERVAL_IN_SECS) {
-            androidNotificationUpdateTick = 0;
-            EngineService.updatePermanentStatusNotification(
-                    new WeakReference<Context>(getActivity()),
-                    downloads,
-                    sDown,
-                    uploads,
-                    sUp);
-
+    private void delayedDHTCheck() {
+        delayedDHTUpdateTimeElapsed += UI_UPDATE_INTERVAL_IN_SECS;
+        if (delayedDHTUpdateTimeElapsed >= DHT_STATUS_UPDATE_INTERVAL_IN_SECS) {
+            delayedDHTUpdateTimeElapsed = 0;
             checkDHTPeers();
         }
     }
+
 
     private void checkDHTPeers() {
         try {

--- a/android/src/com/frostwire/android/gui/services/EngineService.java
+++ b/android/src/com/frostwire/android/gui/services/EngineService.java
@@ -37,6 +37,7 @@ import com.frostwire.android.core.ConfigurationManager;
 import com.frostwire.android.core.Constants;
 import com.frostwire.android.core.player.CoreMediaPlayer;
 import com.frostwire.android.gui.Librarian;
+import com.frostwire.android.gui.NotificationUpdateDemon;
 import com.frostwire.android.gui.activities.MainActivity;
 import com.frostwire.android.gui.transfers.TransferManager;
 import com.frostwire.android.offers.PlayStore;
@@ -69,6 +70,7 @@ public class EngineService extends Service implements IEngineService {
     // services in background
     private final CoreMediaPlayer mediaPlayer;
     private byte state;
+    private NotificationUpdateDemon notificationUpdateDemon;
 
     public EngineService() {
         binder = new EngineServiceBinder();
@@ -95,6 +97,8 @@ public class EngineService extends Service implements IEngineService {
 
         enableReceivers(true);
 
+        initializePermanentNotificationUpdates();
+
         return START_STICKY;
     }
 
@@ -103,6 +107,8 @@ public class EngineService extends Service implements IEngineService {
         LOG.debug("EngineService onDestroy");
 
         enableReceivers(false);
+
+        disablePermanentNotificationUpdates();
 
         ((NotificationManager) getSystemService(NOTIFICATION_SERVICE)).cancelAll();
 
@@ -234,76 +240,6 @@ public class EngineService extends Service implements IEngineService {
         Log.v(TAG, "Engine started");
     }
 
-    public static void updatePermanentStatusNotification(WeakReference<Context> contextRef,
-                                                         int downloads,
-                                                         String sDown,
-                                                         int uploads,
-                                                         String sUp) {
-        if (!Ref.alive(contextRef) ||
-                !ConfigurationManager.instance().getBoolean(Constants.PREF_KEY_GUI_ENABLE_PERMANENT_STATUS_NOTIFICATION)) {
-            return;
-        }
-        final Context context = contextRef.get();
-
-        RemoteViews remoteViews = new RemoteViews(context.getPackageName(),
-                R.layout.view_permanent_status_notification);
-
-        PendingIntent showFrostWireIntent = PendingIntent.getActivity(context,
-                0,
-                new Intent(context,
-                        MainActivity.class).
-                        setAction(Constants.ACTION_SHOW_TRANSFERS).
-                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK),
-                0);
-
-//        PendingIntent showVPNIntent = PendingIntent.getActivity(context,
-//                1,
-//                new Intent(context,
-//                        VPNStatusDetailActivity.class).
-//                        setAction(isVPNactive ?
-//                                Constants.ACTION_SHOW_VPN_STATUS_PROTECTED :
-//                                Constants.ACTION_SHOW_VPN_STATUS_UNPROTECTED).
-//                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK),
-//                0);
-
-        PendingIntent shutdownIntent = PendingIntent.getActivity(context,
-                1,
-                new Intent(context,
-                        MainActivity.class).
-                        setAction(Constants.ACTION_REQUEST_SHUTDOWN).
-                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK),
-                0);
-
-
-        // VPN status
-//        remoteViews.setImageViewResource(R.id.view_permanent_status_vpn_icon, isVPNactive ?
-//                R.drawable.notification_shutdown : R.drawable.notification_shutdown);
-//        remoteViews.setOnClickPendingIntent(R.id.view_permanent_status_vpn_icon, showVPNIntent);
-
-
-        // Click on shutdown image button.
-        remoteViews.setOnClickPendingIntent(R.id.view_permanent_status_shutdown, shutdownIntent);
-
-        // Click on title takes to transfers.
-        remoteViews.setOnClickPendingIntent(R.id.view_permanent_status_text_title, showFrostWireIntent);
-
-        // Transfers status.
-        remoteViews.setTextViewText(R.id.view_permanent_status_text_downloads, downloads + " @ " + sDown);
-        remoteViews.setTextViewText(R.id.view_permanent_status_text_uploads, uploads + " @ " + sUp);
-
-        Notification notification = new NotificationCompat.Builder(context).
-                setSmallIcon(R.drawable.frostwire_notification_flat).
-                setContentIntent(showFrostWireIntent).
-                setContent(remoteViews).
-                build();
-        notification.flags |= Notification.FLAG_NO_CLEAR;
-
-        final NotificationManager notificationManager = (NotificationManager) context.getSystemService(NOTIFICATION_SERVICE);
-        if (notificationManager != null) {
-            notificationManager.notify(FROSTWIRE_STATUS_NOTIFICATION, notification);
-        }
-    }
-
     public synchronized void stopServices(boolean disconnected) {
         if (isStopped() || isStopping() || isDisconnected()) {
             return;
@@ -360,6 +296,17 @@ public class EngineService extends Service implements IEngineService {
 
     private int getNotificationIcon() {
         return R.drawable.frostwire_notification_flat;
+    }
+
+    private void initializePermanentNotificationUpdates(){
+        notificationUpdateDemon = new NotificationUpdateDemon(getApplicationContext());
+        notificationUpdateDemon.start();
+    }
+
+    private void disablePermanentNotificationUpdates(){
+        if(notificationUpdateDemon!=null){
+            notificationUpdateDemon.stop();
+        }
     }
 
     private static long[] buildVenezuelanVibe() {


### PR DESCRIPTION
Ups
continuation of #141 
sorry for making all that mess

Yes, this should reside inside service, but I think NUD has its place. EngineService is almost 400 lines. I'm even thinking about removing the whole updatePermanentStatusNotification(...) from the EngineService into the demon but IDK if there's a reason that it's there (nothing seems to call it). Any thoughts?