### PR TITLE
Desktop buttons

### DIFF
--- a/desktop/src/com/frostwire/gui/tabs/TransfersTab.java
+++ b/desktop/src/com/frostwire/gui/tabs/TransfersTab.java
@@ -77,9 +77,9 @@ public final class TransfersTab extends AbstractTab {
     }
 
     private void initComponents() {
-        mainComponent = new JPanel(new MigLayout("fill, insets 3px 3px 3px 3px, gap 0","[][grow]","[][grow]"));
-        mainComponent.add(createTextFilterComponent(), "w 200!, h 25!, gapleft 5px, center, shrink");
-        mainComponent.add(createFilterToggleButtons(),"w 400!, h 32!, pad 12 0 0 0, right, wrap");
+        mainComponent = new JPanel(new MigLayout("fill, insets 0px 0px 0px 0px, gap 0","[][grow]","[][grow]"));
+        mainComponent.add(createTextFilterComponent(), "w 200!, h 30!, gapleft 5px, center, shrink");
+        mainComponent.add(createFilterToggleButtons(),"w 500!, h 30!, pad 2 0 0 0, right, wrap");
         mainComponent.add(downloadMediator.getComponent(),"cell 0 1 2 1,grow"); // "cell <column> <row> <width> <height>"
         setTransfersFilterModeListener(downloadMediator);
     }
@@ -102,7 +102,7 @@ public final class TransfersTab extends AbstractTab {
     }
 
     private JPanel createFilterToggleButtons() {
-        JPanel filterButtonsContainer = new JPanel(new MigLayout("align center, ins 0 0 0 0"));
+        JPanel filterButtonsContainer = new JPanel(new MigLayout("align right, ins 0 0 0 8"));
         ButtonGroup filterGroup = new ButtonGroup();
         filterAllButton = new JToggleButton(I18n.tr("All"),true);
         filterDownloadingButton = new JToggleButton(I18n.tr("Downloading"),false);
@@ -112,8 +112,8 @@ public final class TransfersTab extends AbstractTab {
         filterDownloadingButton.addActionListener(new OnFilterButtonToggledListener(FilterMode.DOWNLOADING));
         filterSeedingButton.addActionListener(new OnFilterButtonToggledListener(FilterMode.SEEDING));
         filterFinishedButton.addActionListener(new OnFilterButtonToggledListener(FilterMode.FINISHED));
-        final Font smallHelvetica = new Font("Helvetica", Font.PLAIN, 9);
-        final Dimension buttonDimension = new Dimension(90,18);
+        final Font smallHelvetica = new Font("Helvetica", Font.PLAIN, 12);
+        final Dimension buttonDimension = new Dimension(115,28);
         applyFontAndDimensionToFilterToggleButtons(smallHelvetica, buttonDimension,
                 filterAllButton, filterDownloadingButton,filterSeedingButton,filterFinishedButton);
 

--- a/desktop/src/com/frostwire/gui/tabs/TransfersTab.java
+++ b/desktop/src/com/frostwire/gui/tabs/TransfersTab.java
@@ -77,7 +77,7 @@ public final class TransfersTab extends AbstractTab {
     }
 
     private void initComponents() {
-        mainComponent = new JPanel(new MigLayout("fill, insets 0px 0px 0px 0px, gap 0","[][grow]","[][grow]"));
+        mainComponent = new JPanel(new MigLayout("fill, insets 6px 0px 0px 0px, gap 0","[][grow]","[][grow]"));
         mainComponent.add(createTextFilterComponent(), "w 200!, h 30!, gapleft 5px, center, shrink");
         mainComponent.add(createFilterToggleButtons(),"w 500!, h 30!, pad 2 0 0 0, right, wrap");
         mainComponent.add(downloadMediator.getComponent(),"cell 0 1 2 1,grow"); // "cell <column> <row> <width> <height>"

--- a/desktop/src/com/frostwire/gui/tabs/TransfersTab.java
+++ b/desktop/src/com/frostwire/gui/tabs/TransfersTab.java
@@ -23,6 +23,7 @@ import com.limegroup.gnutella.gui.I18n;
 import net.miginfocom.swing.MigLayout;
 
 import javax.swing.*;
+import javax.swing.border.CompoundBorder;
 import java.awt.*;
 import java.awt.event.*;
 
@@ -98,6 +99,10 @@ public final class TransfersTab extends AbstractTab {
         filterText.addKeyListener(new TextFilterKeyAdapter());
         filterText.addFocusListener(new TextFilterFocusAdapter());
         filterText.selectAll();
+        final CompoundBorder compoundBorder =
+                BorderFactory.createCompoundBorder(filterText.getBorder(),
+                        BorderFactory.createEmptyBorder(4, 2, 2, 2));
+        filterText.setBorder(compoundBorder);
         return filterText;
     }
 


### PR DESCRIPTION
Larger, more readable transfer filter buttons and larger filter box (with the box the only thing I was not able to do is to center the text inside? Any ideas how to do it?)
The change came with no loss in vertical space between the search section and transfer section. 

![separate_screen](https://cloud.githubusercontent.com/assets/2339972/16283845/8d9cf65e-389c-11e6-96a2-df04720a1605.png)
![together_screen](https://cloud.githubusercontent.com/assets/2339972/16283844/8d9adb6c-389c-11e6-9a56-f8598f22c86a.png)
