### PR TITLE
[android] abort adnetwork initialization if adremoval purchased

### DIFF
--- a/android/src/com/frostwire/android/offers/Offers.java
+++ b/android/src/com/frostwire/android/offers/Offers.java
@@ -123,24 +123,14 @@ public final class Offers {
         }
     }
 
-    private static void stopAdNetworksIfPurchasedRemoveAds(Context ctx) {
-        final WeakReference<Context> ctxRef = Ref.weak(ctx);
-        THREAD_POOL.execute(new Runnable() {
-            @Override
-            public void run() {
-                if (!Ref.alive(ctxRef)) {
-                    return;
-                }
-                final Context context = ctxRef.get();
-                final ConfigurationManager CM = ConfigurationManager.instance();
-                final PlayStore playStore = PlayStore.getInstance();
-                final Collection<Product> purchasedProducts = Products.listEnabled(playStore, Products.DISABLE_ADS_FEATURE);
-                if (purchasedProducts != null && purchasedProducts.size() > 0) {
-                    LOG.info("Turning off ads, user previously purchased AdRemoval");
-                    CM.setBoolean(Constants.PREF_KEY_GUI_SUPPORT_FROSTWIRE, false);
-                    Offers.stopAdNetworks(context);
-                }
-            }
-        });
+    private static void stopAdNetworksIfPurchasedRemoveAds(Context context) {
+        final ConfigurationManager CM = ConfigurationManager.instance();
+        final PlayStore playStore = PlayStore.getInstance();
+        final Collection<Product> purchasedProducts = Products.listEnabled(playStore, Products.DISABLE_ADS_FEATURE);
+        if (purchasedProducts != null && purchasedProducts.size() > 0) {
+            CM.setBoolean(Constants.PREF_KEY_GUI_SUPPORT_FROSTWIRE, false);
+            Offers.stopAdNetworks(context);
+            LOG.info("Turning off ads, user previously purchased AdRemoval");
+        }
     }
 }


### PR DESCRIPTION
So I tested making a purchase with -store- flavor.
Uninstalled.
installed 'plus' flavor.
And I managed to see the product I bought when I queried Products.listEnabled().

On my previous commit I try to make sure that the support frostwire setting is turned off when a purchase is made in basic. But this should make sure that if that didn't happen, wether you're on basic or plus, adnetworks are kill-switched by having their "started" method return false and when their showInterstitialMethods are invoked they fail right away.

I do this on a separate thread because of the comment earlier on a fix you performed.

Just an idea, perhaps this can be done a lot better.
