### PR TITLE
[android] Fixing tab carousel height calculations. 

### DIFF
--- a/android/apollo/res/values/dimens.xml
+++ b/android/apollo/res/values/dimens.xml
@@ -74,8 +74,6 @@
     <dimen name="notification_expanded_content_padding_top">8.0dip</dimen>
     <dimen name="notification_expanded_collapse_padding">8.0dip</dimen>
 
-    <!-- Height of the shadow asset under the photo -->
-    <dimen name="profile_photo_shadow_height">10.0dip</dimen>
     <!-- Height of the text label in the carousel -->
     <dimen name="profile_carousel_label_height">45.0dip</dimen>
     <dimen name="profile_indicator_height">5.0dip</dimen>

--- a/android/apollo/src/com/andrew/apollo/widgets/ProfileTabCarousel.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/ProfileTabCarousel.java
@@ -78,11 +78,6 @@ public class ProfileTabCarousel extends HorizontalScrollView implements OnTouchL
     private final int mTabDisplayLabelHeight;
 
     /**
-     * Height in pixels of the shadow under the tab carousel
-     */
-    private final int mTabShadowHeight;
-
-    /**
      * First tab click listener
      */
     private final TabClickListener mTabOneTouchInterceptListener = new TabClickListener(
@@ -133,15 +128,13 @@ public class ProfileTabCarousel extends HorizontalScrollView implements OnTouchL
 
     /**
      * @param context The {@link Context} to use
-     * @param attrs The attributes of the XML tag that is inflating the view.
+     * @param attrs   The attributes of the XML tag that is inflating the view.
      */
     public ProfileTabCarousel(final Context context, final AttributeSet attrs) {
         super(context, attrs);
         setOnTouchListener(this);
         final Resources mResources = context.getResources();
-        mTabDisplayLabelHeight = mResources
-                .getDimensionPixelSize(R.dimen.profile_photo_shadow_height);
-        mTabShadowHeight = mResources.getDimensionPixelSize(R.dimen.profile_carousel_label_height);
+        mTabDisplayLabelHeight = mResources.getDimensionPixelSize(R.dimen.profile_carousel_label_height);
         tabWidthScreenWidthFraction = mResources.getFraction(
                 R.fraction.tab_width_screen_percentage, 1, 1);
         tabHeightScreenWidthFraction = mResources.getFraction(
@@ -176,12 +169,12 @@ public class ProfileTabCarousel extends HorizontalScrollView implements OnTouchL
         }
 
         final int tabHeight = Math.round(screenWidth * tabHeightScreenWidthFraction)
-                + mTabShadowHeight;
+                + mTabDisplayLabelHeight;
         if (getChildCount() > 0) {
             final View child = getChildAt(0);
 
             // Add 1 dip of separation between the tabs
-            final int separatorPixels = (int)(TypedValue.applyDimension(
+            final int separatorPixels = (int) (TypedValue.applyDimension(
                     TypedValue.COMPLEX_UNIT_DIP, 1, getResources().getDisplayMetrics()) + 0.5f);
 
             if (mEnableSwipe) {
@@ -194,7 +187,7 @@ public class ProfileTabCarousel extends HorizontalScrollView implements OnTouchL
                         MeasureSpec.makeMeasureSpec(tabHeight, MeasureSpec.EXACTLY));
             }
         }
-        mAllowedVerticalScrollLength = tabHeight - mTabDisplayLabelHeight - mTabShadowHeight;
+        mAllowedVerticalScrollLength = tabHeight - mTabDisplayLabelHeight;
         setMeasuredDimension(resolveSize(screenWidth, widthMeasureSpec),
                 resolveSize(tabHeight, heightMeasureSpec));
     }


### PR DESCRIPTION
Fixing tab carousel height calculations.  Removing unused carousel shadow references #236

Also fixing variable mixup (mTabShadowHeight and mTabDisplayLabelHeight)