### PR TITLE
[android] Make control notification visible

### DIFF
--- a/android/apollo/src/com/andrew/apollo/NotificationHelper.java
+++ b/android/apollo/src/com/andrew/apollo/NotificationHelper.java
@@ -97,6 +97,7 @@ public class NotificationHelper {
                 .setSmallIcon(getNotificationIcon())
                 .setContentIntent(pendingintent)
                 .setPriority(Notification.PRIORITY_DEFAULT)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
                 .setContent(mNotificationTemplate)
                 .build();
         // Control playback from the notification

--- a/android/apollo/src/com/andrew/apollo/NotificationHelper.java
+++ b/android/apollo/src/com/andrew/apollo/NotificationHelper.java
@@ -40,6 +40,11 @@ public class NotificationHelper {
     private static final int APOLLO_MUSIC_SERVICE = 1;
 
     /**
+     * Used to allow player controls on lock screen notification on API 21+ phones
+     */
+    private static final int VISIBILITY_PUBLIC = 1;
+
+    /**
      * NotificationManager
      */
     private final NotificationManager mNotificationManager;
@@ -97,7 +102,7 @@ public class NotificationHelper {
                 .setSmallIcon(getNotificationIcon())
                 .setContentIntent(pendingintent)
                 .setPriority(Notification.PRIORITY_DEFAULT)
-                .setVisibility(Notification.VISIBILITY_PUBLIC)
+                .setVisibility(VISIBILITY_PUBLIC)
                 .setContent(mNotificationTemplate)
                 .build();
         // Control playback from the notification


### PR DESCRIPTION
#252 
This will allow the notification contents to be visible on lock screen when notification privacy is up. On my phone (S5 6.0.1) at least this has a side effect of the fact that the notification in notification area is now expanding (previously lots of ongoing notifications blocked that expansion)
so it affects #251 