### PR TITLE
[android] consistency in showing dark layer in ArtistAlbum screen

### DIFF
--- a/android/apollo/src/com/andrew/apollo/widgets/ProfileTabCarousel.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/ProfileTabCarousel.java
@@ -190,6 +190,7 @@ public class ProfileTabCarousel extends HorizontalScrollView implements OnTouchL
         mAllowedVerticalScrollLength = tabHeight - mTabDisplayLabelHeight;
         setMeasuredDimension(resolveSize(screenWidth, widthMeasureSpec),
                 resolveSize(tabHeight, heightMeasureSpec));
+        updateAlphaLayers();
     }
 
     /**


### PR DESCRIPTION
This fixes an issue reported by @marcelinkaaa in #263 but it doesn't solve the #263 
It was due to a function to update the alpha layer was being fired when there was horizontal scrolling but not before. Added update function to onMeasure(...), so that the image is always darkened.  