### PR TITLE
[android] mute clicks on fake spacer header item in lists

### DIFF
--- a/android/apollo/src/com/andrew/apollo/ui/fragments/profile/ArtistAlbumFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/profile/ArtistAlbumFragment.java
@@ -85,11 +85,13 @@ public class ArtistAlbumFragment extends ApolloFragment<ArtistAlbumAdapter, Albu
                             final int position,
                             final long id) {
         mItem = mAdapter.getItem(position - mAdapter.getOffset());
-        NavUtils.openAlbumProfile(getActivity(),
-                mItem.mAlbumName,
-                mItem.mArtistName,
-                mItem.mAlbumId,
-                MusicUtils.getSongListForAlbum(getActivity(), mItem.mAlbumId));
-        getActivity().finish();
+        if (mItem != null) {
+            NavUtils.openAlbumProfile(getActivity(),
+                    mItem.mAlbumName,
+                    mItem.mArtistName,
+                    mItem.mAlbumId,
+                    MusicUtils.getSongListForAlbum(getActivity(), mItem.mAlbumId));
+            getActivity().finish();
+        }
     }
 }


### PR DESCRIPTION
 in ArtistlbumFragment to avoid NPE.
Not showing the header would be better, but that would result in even worse spaghetti or a rewrite of the whole fragment, view, and adapter. 