### PR TITLE
Preferences design update

### DIFF
--- a/android/res/drawable/ad_menu_item_background_filled.xml
+++ b/android/res/drawable/ad_menu_item_background_filled.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
+ *            Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/app_highlight_text"/>
+    <corners android:radius="3dp"/>
+</shape>

--- a/android/res/layout/view_preference_button_action.xml
+++ b/android/res/layout/view_preference_button_action.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
- * Marcelina Knitter (@marcelinkaaa)
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
  * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -24,16 +23,14 @@
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
     android:minHeight="?android:attr/listPreferredItemHeight"
-    android:orientation="vertical"
-    android:paddingLeft="6dp"
-    android:paddingRight="6dp">
+    android:orientation="vertical" >
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:paddingBottom="10dp"
-        android:paddingLeft="8dp"
-        android:paddingRight="4dp"
+        android:paddingLeft="14dp"
+        android:paddingRight="10dp"
         android:paddingTop="10dp">
 
         <RelativeLayout
@@ -49,7 +46,8 @@
                 android:fadingEdge="horizontal"
                 android:maxLines="2"
                 android:text="@string/dummy_title"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
+                android:textColor="@color/app_text_primary"
+                android:textSize="@dimen/text_medium"/>
 
             <TextView
                 android:id="@+id/view_preference_button_action_summary"
@@ -58,7 +56,7 @@
                 android:layout_below="@+id/view_preference_button_action_title"
                 android:maxLines="3"
                 android:text="@string/dummy_summary"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:textSize="@dimen/text_small" />
         </RelativeLayout>
 
         <LinearLayout
@@ -73,7 +71,7 @@
                 android:id="@+id/view_preference_button_action_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
+                android:gravity="center"
                 android:orientation="vertical"
                 android:text="@string/dummy_action" />
 

--- a/android/res/layout/view_preference_buy_ads.xml
+++ b/android/res/layout/view_preference_buy_ads.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
+ *            Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="7dp"
+        android:layout_marginTop="7dp"
+        android:gravity="center_vertical"
+        android:minHeight="?android:attr/listPreferredItemHeight"
+        android:orientation="vertical"
+        android:paddingLeft="14dp"
+        android:paddingRight="10dp">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@android:id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="marquee"
+                android:fadingEdge="horizontal"
+                android:maxLines="1"
+                android:textColor="@color/app_text_primary"
+                android:textSize="@dimen/text_medium" />
+
+            <TextView
+                android:id="@+id/view_preference_buy_ads_pro_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginLeft="10dp"
+                android:background="@drawable/ad_menu_item_background_filled"
+                android:paddingBottom="2dp"
+                android:paddingLeft="5dp"
+                android:paddingRight="5dp"
+                android:paddingTop="2dp"
+                android:text="PRO"
+                android:textColor="@color/basic_white"
+                android:textSize="@dimen/text_x_small"
+                android:textStyle="bold" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@android:id/summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="3"
+            android:textSize="@dimen/text_small" />
+
+    </LinearLayout>
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@drawable/layout_divider_1_gray" />
+
+</LinearLayout>

--- a/android/res/layout/view_preference_checkbox_seeding.xml
+++ b/android/res/layout/view_preference_checkbox_seeding.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
  * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,16 +23,14 @@
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
     android:minHeight="?android:attr/listPreferredItemHeight"
-    android:orientation="vertical"
-    android:paddingLeft="6dp"
-    android:paddingRight="6dp">
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:paddingBottom="10dp"
-        android:paddingLeft="8dp"
-        android:paddingRight="4dp"
+        android:paddingLeft="15dp"
+        android:paddingRight="15dp"
         android:paddingTop="10dp">
 
         <RelativeLayout
@@ -48,7 +46,7 @@
                 android:fadingEdge="horizontal"
                 android:maxLines="2"
                 android:text="@string/dummy_title"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textSize="@dimen/text_medium"
                 android:textColor="@color/disabled_text_selector" />
 
             <TextView
@@ -58,8 +56,7 @@
                 android:layout_below="@+id/view_preference_checkbox_seeding_title"
                 android:maxLines="3"
                 android:text="@string/dummy_summary"
-                android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="@color/disabled_text_selector" />
+                android:textSize="@dimen/text_size_small" />
 
         </RelativeLayout>
 
@@ -81,9 +78,4 @@
                 android:gravity="center_vertical" />
         </LinearLayout>
     </LinearLayout>
-
-    <ImageView
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@drawable/layout_divider_1_gray" />
 </LinearLayout>

--- a/android/res/layout/view_preference_simple_action.xml
+++ b/android/res/layout/view_preference_simple_action.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
  * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -21,24 +21,20 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
-    android:minHeight="?android:attr/listPreferredItemHeight"
-    android:orientation="vertical"
-    android:paddingLeft="6dp"
-    android:paddingRight="6dp">
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingBottom="10dp"
-        android:paddingLeft="8dp"
-        android:paddingRight="4dp"
-        android:paddingTop="10dp">
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/listPreferredItemHeight"
+        android:paddingLeft="14dp"
+        android:paddingRight="10dp">
 
         <RelativeLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            android:gravity="center_vertical">
 
             <TextView
                 android:id="@android:id/title"
@@ -47,8 +43,8 @@
                 android:ellipsize="marquee"
                 android:fadingEdge="horizontal"
                 android:maxLines="2"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textColor="@color/app_text_primary" />
+                android:textColor="@color/app_text_primary"
+                android:textSize="@dimen/text_medium" />
 
             <TextView
                 android:id="@android:id/summary"
@@ -57,7 +53,7 @@
                 android:layout_alignLeft="@android:id/title"
                 android:layout_below="@android:id/title"
                 android:maxLines="3"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:textSize="@dimen/text_small" />
 
         </RelativeLayout>
 

--- a/android/res/layout/view_preference_simple_action_padding.xml
+++ b/android/res/layout/view_preference_simple_action_padding.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
+ *            Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/listPreferredItemHeight"
+        android:paddingBottom="10dp"
+        android:paddingLeft="14dp"
+        android:paddingRight="11dp"
+        android:paddingTop="12dp">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@android:id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="marquee"
+                android:fadingEdge="horizontal"
+                android:maxLines="2"
+                android:textColor="@color/app_text_primary"
+                android:textSize="@dimen/text_medium" />
+
+            <TextView
+                android:id="@android:id/summary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignLeft="@android:id/title"
+                android:layout_below="@android:id/title"
+                android:maxLines="3"
+                android:textSize="@dimen/text_small" />
+
+        </RelativeLayout>
+
+        <!-- Preference should place its actual preference widget here. -->
+        <LinearLayout
+            android:id="@+android:id/widget_frame"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:orientation="vertical" />
+
+    </LinearLayout>
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@drawable/layout_divider_1_gray" />
+</LinearLayout>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -236,7 +236,7 @@
     <string name="mobile_data">Mobile Data</string>
     <string name="media_player_failed">Media player failed</string>
     <string name="activity_media_player_name">Media Player</string>
-    <string name="search_settings">Search Settings</string>
+    <string name="search_settings">Search</string>
     <string name="use_clearbits">Use ClearBits.net</string>
     <string name="use_tpb">Use TPB</string>
     <string name="use_tpb_summary">TPB is magnet based, works only on Wi-Fi</string>
@@ -319,7 +319,7 @@
     <string name="download_type_not_supported">Download Type not supported</string>
     <string name="im_on_it">I\'m on it…</string>
     <string name="hint_transfers">Use "menu" for bulk actions</string>
-    <string name="torrent_settings">Torrent Settings</string>
+    <string name="torrent_settings">Torrent Preferences</string>
     <string name="torrent_max_download_speed_summary">Max Download Speed (0 means unlimited)</string>
     <string name="torrent_max_download_speed">Max Download Speed</string>
     <string name="torrent_max_upload_speed_summary">Max Upload Speed (0 means unlimited)</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -651,4 +651,7 @@
     <string name="frostwire_sticker_and_more">FrostWire stickers and more</string>
     <string name="donate_your_time">Donate your time</string>
     <string name="changelog">Changelog</string>
+    <string name="general">General</string>
+    <string name="search_torrent_settings">Search/Torrent Settings</string>
+    <string name="interface_and_notifications">Interface and Notifications</string>
 </resources>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -112,15 +112,10 @@
 
     <!-- Preferences -->
 
-    <style name="Preferences" parent="android:Theme.Holo.Light">
-        <item name="android:icon">@null</item>
-        <item name="android:actionBarStyle">@style/ActionBar</item>
-        <item name="android:homeAsUpIndicator">@drawable/home_as_up_padding</item>
-        <item name="android:checkboxStyle">@style/PreferencesCheckboxStyle</item>
+    <style name="Preferences" parent="Theme.FrostWire">
         <item name="android:listSeparatorTextViewStyle">@style/PreferenceListSeparator</item>
-        <item name="android:textColorPrimary">@color/app_text_primary</item>
-        <item name="android:textColorSecondary">@color/app_text_secondary</item>
         <item name="android:windowBackground">@color/basic_white</item>
+        <item name="android:windowActionBar">false</item>
         <item name="android:listViewStyle">@style/PreferencesListView</item>
         <item name="android:listDivider">@drawable/layout_divider_1_gray</item>
         <item name="android:listSelector">@drawable/listview_item_press_background_selector</item>
@@ -143,6 +138,7 @@
 
     <style name="PreferencesListView">
         <item name="android:padding">0dp</item>
+        <item name="android:listSeparatorTextViewStyle">@style/PreferenceListSeparator</item>
     </style>
 
     <style name="PreferencesCheckboxStyle">

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -21,7 +21,11 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="Theme.FrostWire" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">@color/basic_blue</item>
         <item name="colorPrimaryDark">@android:color/black</item>
+        <item name="colorAccent">@color/basic_blue_darker_highlight</item>
+        <item name="android:textColorPrimary">@color/app_text_primary</item>
+        <item name="android:textColorSecondary">@color/app_text_secondary</item>
         <item name="toolbarNavigationButtonStyle">@style/ToolbarNavigationButtonStyle</item>
         <item name="toolbarStyle">@style/ToolbarStyle</item>
     </style>

--- a/android/res/xml/application_preferences.xml
+++ b/android/res/xml/application_preferences.xml
@@ -29,7 +29,6 @@
             android:title="@string/bittorrent" />
         <SwitchPreference
             android:key="frostwire.prefs.network.use_mobile_data"
-            android:layout="@layout/view_preference_simple_action"
             android:summary="@string/use_mobile_data_summary"
             android:title="@string/use_mobile_data" />
         <!--Switch preference below to replace "frostwire.prefs.network.use_mobile_data" above-->
@@ -224,7 +223,7 @@
                 android:title="@string/haptic_feedback" />
             <CheckBoxPreference
                 android:key="frostwire.prefs.gui.distraction_free_search"
-                android:layout="@layout/view_preference_simple_action"
+                android:layout="@layout/view_preference_simple_action_padding"
                 android:title="@string/distraction_free_search_results"
                 android:summary="@string/distraction_free_search_results_summary"/>
             <CheckBoxPreference

--- a/android/res/xml/application_preferences.xml
+++ b/android/res/xml/application_preferences.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,11 +21,22 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:frostwire="http://schemas.android.com/apk/res-auto">
 
-    <PreferenceCategory android:key="frostwire.prefs.general">
+    <PreferenceCategory android:key="frostwire.prefs.general"
+        android:title="@string/general">
         <SwitchPreference
             android:key="frostwire.prefs.internal.connect_disconnect"
             android:summary="@string/bittorrent_network_summary"
             android:title="@string/bittorrent" />
+        <SwitchPreference
+            android:key="frostwire.prefs.network.use_mobile_data"
+            android:layout="@layout/view_preference_simple_action"
+            android:summary="@string/use_mobile_data_summary"
+            android:title="@string/use_mobile_data" />
+        <!--Switch preference below to replace "frostwire.prefs.network.use_mobile_data" above-->
+        <!--<SwitchPreference-->
+            <!--android:key="frostwire.prefs.network.use_mobile_data"-->
+            <!--android:summary="@string/wifi_networks_only_summary"-->
+            <!--android:title="@string/wifi_networks_only" />-->
         <com.frostwire.android.gui.views.preference.StoragePreference
             android:key="frostwire.prefs.storage.path"
             android:summary="@string/storage_preference_summary"
@@ -38,216 +49,203 @@
         </Preference>
     </PreferenceCategory>
 
-    <PreferenceScreen
-        android:key="frostwire.prefs.torrent.preference_category"
-        android:persistent="false"
-        android:title="@string/torrent_settings">
-        <CheckBoxPreference
-            android:key="frostwire.prefs.network.use_mobile_data"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_mobile_data_summary"
-            android:title="@string/use_mobile_data" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.torrent.seed_finished_torrents"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/seed_finished_torrents_summary"
-            android:title="@string/seed_finished_torrents" />
-        <com.frostwire.android.gui.views.preference.CheckBoxSeedingPreference
-            android:key="frostwire.prefs.torrent.seed_finished_torrents_wifi_only"
-            android:summary="@string/seed_finished_torrents_wifi_only_summary"
-            android:title="@string/seed_finished_torrents_wifi_only" />
-        <SwitchPreference
-            android:key="froswire.prefs.network.enable_dht"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/enable_dht_summary"
-            android:title="@string/enable_dht" />
-        <com.frostwire.android.gui.views.preference.NumberPickerPreference
-            android:key="frostwire.prefs.torrent.max_download_speed"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/torrent_max_download_speed_summary"
-            android:title="@string/torrent_max_download_speed"
-            frostwire:picker_defaultValue="0"
-            frostwire:picker_endRange="102400"
-            frostwire:picker_startRange="0" />
-        <com.frostwire.android.gui.views.preference.NumberPickerPreference
-            android:key="frostwire.prefs.torrent.max_upload_speed"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/torrent_max_upload_speed_summary"
-            android:title="@string/torrent_max_upload_speed"
-            frostwire:picker_defaultValue="0"
-            frostwire:picker_endRange="102400"
-            frostwire:picker_startRange="0" />
-        <com.frostwire.android.gui.views.preference.NumberPickerPreference
-            android:key="frostwire.prefs.torrent.max_downloads"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/torrent_max_downloads_summary"
-            android:title="@string/torrent_max_downloads"
-            frostwire:picker_defaultValue="4"
-            frostwire:picker_endRange="10"
-            frostwire:picker_startRange="1" />
-        <com.frostwire.android.gui.views.preference.NumberPickerPreference
-            android:key="frostwire.prefs.torrent.max_uploads"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/torrent_max_uploads_summary"
-            android:title="@string/torrent_max_uploads"
-            frostwire:picker_defaultValue="4"
-            frostwire:picker_endRange="10"
-            frostwire:picker_startRange="1" />
-        <com.frostwire.android.gui.views.preference.NumberPickerPreference
-            android:key="frostwire.prefs.torrent.max_total_connections"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/torrent_max_total_connections_summary"
-            android:title="@string/torrent_max_total_connections"
-            frostwire:picker_defaultValue="200"
-            frostwire:picker_endRange="200"
-            frostwire:picker_startRange="10" />
-        <com.frostwire.android.gui.views.preference.NumberPickerPreference
-            android:key="frostwire.prefs.torrent.max_peers"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/torrent_max_peers_summary"
-            android:title="@string/torrent_max_peers"
-            frostwire:picker_defaultValue="200"
-            frostwire:picker_endRange="200"
-            frostwire:picker_startRange="10" />
+    <PreferenceCategory android:title="@string/search_torrent_settings">
+        <PreferenceScreen
+            android:key="frostwire.prefs.search.preference_category"
+            android:persistent="false"
+            android:title="@string/search_settings">
+            <com.frostwire.android.gui.activities.ToggleAllSearchEnginesPreference
+                android:key="frostwire.prefs.search.preference_category.select_all"
+                android:title="@string/select_deselect_all" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_archiveorg"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_archiveorg" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_bitsnoop"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_bitsnoop" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_btjunkie"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_btjunkie" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_extratorrent"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_extratorrent" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_eztv"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_eztv" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_frostclick"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_frostclick" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_mininova"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_mininova" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_monova"
+                android:layout="@layout/view_preference_simple_action"
+                android:summary="@string/use_monova_summary"
+                android:title="@string/use_monova" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_soundcloud"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_soundcloud" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_tpb"
+                android:layout="@layout/view_preference_simple_action"
+                android:summary="@string/use_tpb_summary"
+                android:title="@string/use_tpb" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_torlock"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_torlock" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_torrentdownloads"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_torrentdownloads" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_limetorrents"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_limetorrents" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_yify"
+                android:layout="@layout/view_preference_simple_action"
+                android:summary="@string/use_yify_summary"
+                android:title="@string/use_yify" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.search.use_youtube"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/use_youtube" />
 
-        <com.frostwire.android.gui.views.preference.ButtonActionPreference
-            android:key="frostwire.prefs.internal.clear_index"
-            android:summary="@string/clear_search_cache_summary"
-            android:title="@string/clear_search_cache"
-            frostwire:button_text="@string/clear" />
-    </PreferenceScreen>
+            <com.frostwire.android.gui.views.preference.ButtonActionPreference
+                android:key="frostwire.prefs.internal.clear_index"
+                android:summary="@string/clear_search_cache_summary"
+                android:title="@string/clear_search_cache"
+                frostwire:button_text="@string/clear" />
+        </PreferenceScreen>
 
-    <PreferenceScreen
-        android:key="frostwire.prefs.search.preference_category"
-        android:persistent="false"
-        android:title="@string/search_settings">
-        <com.frostwire.android.gui.activities.ToggleAllSearchEnginesPreference
-            android:key="frostwire.prefs.search.preference_category.select_all"
-            android:title="@string/select_deselect_all" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_archiveorg"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_archiveorg"
-            android:title="@string/use_archiveorg" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_bitsnoop"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_bitsnoop"
-            android:title="@string/use_bitsnoop" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_btjunkie"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_btjunkie"
-            android:title="@string/use_btjunkie" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_extratorrent"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_extratorrent"
-            android:title="@string/use_extratorrent" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_eztv"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_eztv"
-            android:title="@string/use_eztv" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_frostclick"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_frostclick"
-            android:title="@string/use_frostclick" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_mininova"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_mininova"
-            android:title="@string/use_mininova" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_monova"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_monova_summary"
-            android:title="@string/use_monova" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_soundcloud"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_soundcloud"
-            android:title="@string/use_soundcloud" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_tpb"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_tpb_summary"
-            android:title="@string/use_tpb" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_torlock"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_torlock"
-            android:title="@string/use_torlock" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_torrentdownloads"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_torrentdownloads"
-            android:title="@string/use_torrentdownloads" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_limetorrents"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_limetorrents"
-            android:title="@string/use_limetorrents" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_yify"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_yify_summary"
-            android:title="@string/use_yify" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.search.use_youtube"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/use_youtube"
-            android:title="@string/use_youtube" />
-    </PreferenceScreen>
-    <PreferenceScreen
-        android:key="frostwire.prefs.other.preference_category"
-        android:persistent="false"
+        <PreferenceScreen
+            android:key="frostwire.prefs.torrent.preference_category"
+            android:persistent="false"
+            android:title="@string/torrent_settings">
+            <PreferenceCategory
+                android:title="Privacy and sharing">
+                <CheckBoxPreference
+                    android:key="frostwire.prefs.torrent.seed_finished_torrents"
+                    android:summary="@string/seed_finished_torrents_summary"
+                    android:title="@string/seed_finished_torrents" />
+                <com.frostwire.android.gui.views.preference.CheckBoxSeedingPreference
+                    android:key="frostwire.prefs.torrent.seed_finished_torrents_wifi_only"
+                    android:summary="@string/seed_finished_torrents_wifi_only_summary"
+                    android:title="@string/seed_finished_torrents_wifi_only" />
+            </PreferenceCategory>
+            <PreferenceCategory
+                android:title="Bandwidth and network">
+                <SwitchPreference
+                    android:key="froswire.prefs.network.enable_dht"
+                    android:summary="@string/enable_dht_summary"
+                    android:title="@string/enable_dht" />
+                <com.frostwire.android.gui.views.preference.NumberPickerPreference
+                    android:key="frostwire.prefs.torrent.max_download_speed"
+                    android:summary="@string/torrent_max_download_speed_summary"
+                    android:title="@string/torrent_max_download_speed"
+                    frostwire:picker_defaultValue="0"
+                    frostwire:picker_endRange="102400"
+                    frostwire:picker_startRange="0" />
+                <com.frostwire.android.gui.views.preference.NumberPickerPreference
+                    android:key="frostwire.prefs.torrent.max_upload_speed"
+                    android:summary="@string/torrent_max_upload_speed_summary"
+                    android:title="@string/torrent_max_upload_speed"
+                    frostwire:picker_defaultValue="0"
+                    frostwire:picker_endRange="102400"
+                    frostwire:picker_startRange="0" />
+                <com.frostwire.android.gui.views.preference.NumberPickerPreference
+                    android:key="frostwire.prefs.torrent.max_downloads"
+                    android:summary="@string/torrent_max_downloads_summary"
+                    android:title="@string/torrent_max_downloads"
+                    frostwire:picker_defaultValue="4"
+                    frostwire:picker_endRange="10"
+                    frostwire:picker_startRange="1" />
+                <com.frostwire.android.gui.views.preference.NumberPickerPreference
+                    android:key="frostwire.prefs.torrent.max_uploads"
+                    android:summary="@string/torrent_max_uploads_summary"
+                    android:title="@string/torrent_max_uploads"
+                    frostwire:picker_defaultValue="4"
+                    frostwire:picker_endRange="10"
+                    frostwire:picker_startRange="1" />
+                <com.frostwire.android.gui.views.preference.NumberPickerPreference
+                    android:key="frostwire.prefs.torrent.max_total_connections"
+                    android:summary="@string/torrent_max_total_connections_summary"
+                    android:title="@string/torrent_max_total_connections"
+                    frostwire:picker_defaultValue="200"
+                    frostwire:picker_endRange="200"
+                    frostwire:picker_startRange="10" />
+                <com.frostwire.android.gui.views.preference.NumberPickerPreference
+                    android:key="frostwire.prefs.torrent.max_peers"
+                    android:summary="@string/torrent_max_peers_summary"
+                    android:title="@string/torrent_max_peers"
+                    frostwire:picker_defaultValue="200"
+                    frostwire:picker_endRange="200"
+                    frostwire:picker_startRange="10" />
+            </PreferenceCategory>
+        </PreferenceScreen>
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/other_settings">
-        <CheckBoxPreference
-            android:key="frostwire.prefs.gui.enable_permanent_status_notification"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/notify_frostwire_is_running_summary"
-            android:title="@string/notify_frostwire_is_running" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.gui.show_transfers_on_download_start"
-            android:layout="@layout/view_preference_simple_action"
-            android:title="@string/show_transfers_on_download_start" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.gui.show_new_transfer_dialog"
-            android:layout="@layout/view_preference_simple_action"
-            android:title="@string/show_new_transfer_dialog" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.gui.vibrate_on_finished_download"
-            android:layout="@layout/view_preference_simple_action"
-            android:title="@string/vibrate_on_finished_download" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.gui.haptic_feedback_on"
-            android:layout="@layout/view_preference_simple_action"
-            android:title="@string/haptic_feedback" />
-        <CheckBoxPreference
-            android:key="frostwire.prefs.gui.distraction_free_search"
-            android:layout="@layout/view_preference_simple_action"
-            android:title="@string/distraction_free_search_results"
-            android:summary="@string/distraction_free_search_results_summary"/>
-        <CheckBoxPreference
-            android:key="frostwire.prefs.uxstats.enabled"
-            android:layout="@layout/view_preference_simple_action"
-            android:summary="@string/anonymous_usage_statistics_summary"
-            android:title="@string/anonymous_usage_statistics" />
-    </PreferenceScreen>
-    <Preference
-        android:key="frostwire.prefs.offers.buy_no_ads"
-        android:summary="@string/remove_ads_description"
-        android:title="@string/remove_ads"
-        android:id="@+id/preference"></Preference>
-    <Preference
-        android:key="frostwire.prefs.show_about"
-        android:title="@string/about">
-        <intent
-            android:action="android.intent.action.VIEW"
-            android:targetClass="com.frostwire.android.gui.activities.AboutActivity"
-            android:targetPackage="com.frostwire.android" />
-    </Preference>
+        <PreferenceScreen
+            android:key="frostwire.prefs.other.preference_category"
+            android:persistent="false"
+            android:title="@string/interface_and_notifications">
+            <CheckBoxPreference
+                android:key="frostwire.prefs.gui.enable_permanent_status_notification"
+                android:layout="@layout/view_preference_simple_action_padding"
+                android:summary="@string/notify_frostwire_is_running_summary"
+                android:title="@string/notify_frostwire_is_running" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.gui.show_transfers_on_download_start"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/show_transfers_on_download_start" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.gui.show_new_transfer_dialog"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/show_new_transfer_dialog" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.gui.vibrate_on_finished_download"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/vibrate_on_finished_download" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.gui.haptic_feedback_on"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/haptic_feedback" />
+            <CheckBoxPreference
+                android:key="frostwire.prefs.gui.distraction_free_search"
+                android:layout="@layout/view_preference_simple_action"
+                android:title="@string/distraction_free_search_results"
+                android:summary="@string/distraction_free_search_results_summary"/>
+            <CheckBoxPreference
+                android:key="frostwire.prefs.uxstats.enabled"
+                android:layout="@layout/view_preference_simple_action_padding"
+                android:summary="@string/anonymous_usage_statistics_summary"
+                android:title="@string/anonymous_usage_statistics" />
+        </PreferenceScreen>
 
+        <Preference
+            android:key="frostwire.prefs.show_about"
+            android:title="@string/about">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:targetClass="com.frostwire.android.gui.activities.AboutActivity"
+                android:targetPackage="com.frostwire.android" />
+        </Preference>
+        <Preference
+            android:key="frostwire.prefs.offers.buy_no_ads"
+            android:summary="@string/remove_ads_description"
+            android:title="@string/remove_ads"
+            android:layout="@layout/view_preference_buy_ads"/>
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/android/src/com/frostwire/android/gui/activities/SettingsActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/SettingsActivity.java
@@ -18,7 +18,6 @@
 
 package com.frostwire.android.gui.activities;
 
-import android.app.ActionBar;
 import android.app.Activity;
 import android.app.Dialog;
 import android.app.NotificationManager;
@@ -30,6 +29,8 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.*;
 import android.preference.Preference.OnPreferenceChangeListener;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -98,11 +99,20 @@ public class SettingsActivity extends PreferenceActivity {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.application_preferences);
 
-        getListView().setPadding(20, 0, 20, 0);
+        LinearLayout root = (LinearLayout) findViewById(android.R.id.list).getParent().getParent().getParent();
+        Toolbar settingsToolbar = (Toolbar) LayoutInflater.from(this).inflate(R.layout.toolbar_main, root, false);
+        root.addView(settingsToolbar, 0); // insert at top
+        settingsToolbar.setTitle(R.string.settings);
+        settingsToolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
+
+        getListView().setPadding(0, 0, 0, 0);
         getListView().setDivider(new ColorDrawable(this.getResources().getColor(R.color.basic_gray_dark_solid)));
         getListView().setDividerHeight(1);
-
-        hideActionBarIcon(getActionBar());
 
         setupComponents();
 
@@ -121,14 +131,6 @@ public class SettingsActivity extends PreferenceActivity {
         updateConnectSwitch();
     }
 
-    private void hideActionBarIcon(ActionBar bar) {
-        if (bar != null) {
-            bar.setDisplayHomeAsUpEnabled(true);
-            bar.setDisplayShowHomeEnabled(false);
-            bar.setDisplayShowTitleEnabled(true);
-            bar.setIcon(android.R.color.transparent);
-        }
-    }
 
     private void setupComponents() {
         setupConnectSwitch();
@@ -657,12 +659,32 @@ public class SettingsActivity extends PreferenceActivity {
     @Override
     public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
 
-        boolean r = super.onPreferenceTreeClick(preferenceScreen, preference);
+        // If the user has clicked on a preference screen, set up the screen
         if (preference instanceof PreferenceScreen) {
-            initializePreferenceScreen((PreferenceScreen) preference);
-            currentPreferenceKey = preference.getKey();
+            setUpNestedScreen((PreferenceScreen) preference);
         }
-        return r;
+
+        return false;
+    }
+
+    public void setUpNestedScreen(PreferenceScreen preferenceScreen) {
+        final Dialog dialog = preferenceScreen.getDialog();
+
+        Toolbar nestedSettingsToolbar;
+
+        LinearLayout root = (LinearLayout) dialog.findViewById(android.R.id.list).getParent();
+        nestedSettingsToolbar = (Toolbar) LayoutInflater.from(this).inflate(R.layout.toolbar_main, root, false);
+        // insert at top
+        root.addView(nestedSettingsToolbar, 0);
+
+        nestedSettingsToolbar.setTitle(preferenceScreen.getTitle());
+
+        nestedSettingsToolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dialog.dismiss();
+            }
+        });
     }
 
     /**
@@ -692,7 +714,6 @@ public class SettingsActivity extends PreferenceActivity {
                 }
             });
 
-            hideActionBarIcon(dialog.getActionBar());
             View homeButton = dialog.findViewById(android.R.id.home);
 
             if (homeButton != null) {


### PR DESCRIPTION
@aldenml - Update to the layout of preferences as discussed with @gubatron, added toolbar to SettingsActivity and its nested screens, added material theme, and adjusted padding/dividers/text sizes of layouts used according to guidelines. 

All preferences are working as before, no functionality changes made. 
Next step: add/replace talked about preferences ('Download on WiFi only' etc.), change number picker dialog as per discussion with grzesiek... Clean up settings code - a lot of it is deprecated already. 