### PR TITLE
[android] added toolbar and new material theme to Preferences

### DIFF
--- a/android/res/layout/view_preference_button_action.xml
+++ b/android/res/layout/view_preference_button_action.xml
@@ -73,7 +73,7 @@
                 android:id="@+id/view_preference_button_action_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
+                android:gravity="center"
                 android:orientation="vertical"
                 android:text="@string/dummy_action" />
 

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -112,14 +112,7 @@
 
     <!-- Preferences -->
 
-    <style name="Preferences" parent="android:Theme.Holo.Light">
-        <item name="android:icon">@null</item>
-        <item name="android:actionBarStyle">@style/ActionBar</item>
-        <item name="android:homeAsUpIndicator">@drawable/home_as_up_padding</item>
-        <item name="android:checkboxStyle">@style/PreferencesCheckboxStyle</item>
-        <item name="android:listSeparatorTextViewStyle">@style/PreferenceListSeparator</item>
-        <item name="android:textColorPrimary">@color/app_text_primary</item>
-        <item name="android:textColorSecondary">@color/app_text_secondary</item>
+    <style name="Preferences" parent="Theme.FrostWire">
         <item name="android:windowBackground">@color/basic_white</item>
         <item name="android:listViewStyle">@style/PreferencesListView</item>
         <item name="android:listDivider">@drawable/layout_divider_1_gray</item>
@@ -134,11 +127,6 @@
         <item name="android:textSize">@dimen/text_x_medium</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:textStyle">bold</item>
-    </style>
-
-    <style name="PreferenceListSeparator">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">1dp</item>
     </style>
 
     <style name="PreferencesListView">

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -21,7 +21,11 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="Theme.FrostWire" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">@color/basic_blue</item>
         <item name="colorPrimaryDark">@android:color/black</item>
+        <item name="colorAccent">@color/basic_blue_darker_highlight</item>
+        <item name="android:textColorPrimary">@color/app_text_primary</item>
+        <item name="android:textColorSecondary">@color/app_text_secondary</item>
         <item name="toolbarNavigationButtonStyle">@style/ToolbarNavigationButtonStyle</item>
         <item name="toolbarStyle">@style/ToolbarStyle</item>
     </style>

--- a/android/src/com/frostwire/android/gui/activities/SettingsActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/SettingsActivity.java
@@ -18,7 +18,6 @@
 
 package com.frostwire.android.gui.activities;
 
-import android.app.ActionBar;
 import android.app.Activity;
 import android.app.Dialog;
 import android.app.NotificationManager;
@@ -30,6 +29,8 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.*;
 import android.preference.Preference.OnPreferenceChangeListener;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -98,11 +99,20 @@ public class SettingsActivity extends PreferenceActivity {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.application_preferences);
 
-        getListView().setPadding(20, 0, 20, 0);
+        LinearLayout root = (LinearLayout) findViewById(android.R.id.list).getParent();
+        Toolbar settingsToolbar = (Toolbar) LayoutInflater.from(this).inflate(R.layout.toolbar_main, root, false);
+        root.addView(settingsToolbar, 0); // insert at top
+        settingsToolbar.setTitle(R.string.settings);
+        settingsToolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
+
+        getListView().setPadding(0, 0, 0, 0);
         getListView().setDivider(new ColorDrawable(this.getResources().getColor(R.color.basic_gray_dark_solid)));
         getListView().setDividerHeight(1);
-
-        hideActionBarIcon(getActionBar());
 
         setupComponents();
 
@@ -119,15 +129,6 @@ public class SettingsActivity extends PreferenceActivity {
         }
 
         updateConnectSwitch();
-    }
-
-    private void hideActionBarIcon(ActionBar bar) {
-        if (bar != null) {
-            bar.setDisplayHomeAsUpEnabled(true);
-            bar.setDisplayShowHomeEnabled(false);
-            bar.setDisplayShowTitleEnabled(true);
-            bar.setIcon(android.R.color.transparent);
-        }
     }
 
     private void setupComponents() {
@@ -657,12 +658,32 @@ public class SettingsActivity extends PreferenceActivity {
     @Override
     public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
 
-        boolean r = super.onPreferenceTreeClick(preferenceScreen, preference);
+        // If the user has clicked on a preference screen, set up the screen
         if (preference instanceof PreferenceScreen) {
-            initializePreferenceScreen((PreferenceScreen) preference);
-            currentPreferenceKey = preference.getKey();
+            setUpNestedScreen((PreferenceScreen) preference);
         }
-        return r;
+
+        return false;
+    }
+
+    public void setUpNestedScreen(PreferenceScreen preferenceScreen) {
+        final Dialog dialog = preferenceScreen.getDialog();
+
+        Toolbar nestedSettingsToolbar;
+
+        LinearLayout root = (LinearLayout) dialog.findViewById(android.R.id.list).getParent();
+        nestedSettingsToolbar = (Toolbar) LayoutInflater.from(this).inflate(R.layout.toolbar_main, root, false);
+        // insert at top
+        root.addView(nestedSettingsToolbar, 0);
+
+        nestedSettingsToolbar.setTitle(preferenceScreen.getTitle());
+
+        nestedSettingsToolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dialog.dismiss();
+            }
+        });
     }
 
     /**
@@ -692,7 +713,6 @@ public class SettingsActivity extends PreferenceActivity {
                 }
             });
 
-            hideActionBarIcon(dialog.getActionBar());
             View homeButton = dialog.findViewById(android.R.id.home);
 
             if (homeButton != null) {


### PR DESCRIPTION
@aldenml here is just the addition of new theme and a toolbar. No layout or bigger style changes.
There is an empty space over the first preference (BitTorrent connection status) - it is due to the material theme in connection to <PreferenceCategory> and it's title - which we don't use in the old layout but the space remains. 
In the new layout this will not be an issue. But let me know if you decide to keep this layout for a longer while - I will look into a styling/layout solution to get rid of it. 