### PR TITLE
[android] added styles and custom layouts to the new material settings

### DIFF
--- a/android/res/drawable/ad_menu_item_background_filled.xml
+++ b/android/res/drawable/ad_menu_item_background_filled.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
+ * Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/basic_blue_highlight"/>
+    <corners android:radius="2dp"/>
+</shape>

--- a/android/res/layout/view_preference_button_action_2.xml
+++ b/android/res/layout/view_preference_button_action_2.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
+ * Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="horizontal"
+    android:padding="@dimen/settings_list_item_inner_padding">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/view_preference_button_action_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="2"
+            android:text="@string/dummy_title"
+            android:textColor="@color/app_text_primary"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:id="@+id/view_preference_button_action_summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="3"
+            android:text="@string/dummy_summary"
+            android:textSize="@dimen/text_small" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/widget_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="right|center_vertical"
+        android:orientation="vertical">
+
+        <Button
+            android:id="@+id/view_preference_button_action_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dummy_action" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/android/res/layout/view_preference_buy_ads_2.xml
+++ b/android/res/layout/view_preference_buy_ads_2.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
+ * Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="vertical"
+    android:padding="@dimen/settings_list_item_inner_padding">
+
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@android:id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="marquee"
+            android:fadingEdge="horizontal"
+            android:maxLines="1"
+            android:textColor="@color/app_text_primary"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:id="@+id/view_preference_buy_ads_pro_textview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginLeft="10dp"
+            android:background="@drawable/ad_menu_item_background_filled"
+            android:paddingBottom="2dp"
+            android:paddingLeft="7dp"
+            android:paddingRight="7dp"
+            android:paddingTop="2dp"
+            android:text="@string/pro"
+            android:textColor="@color/basic_white"
+            android:textSize="@dimen/text_x_small"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@android:id/summary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxLines="3"
+        android:textSize="@dimen/text_small" />
+
+</LinearLayout>
+

--- a/android/res/layout/view_preference_checkbox_seeding_2.xml
+++ b/android/res/layout/view_preference_checkbox_seeding_2.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="horizontal"
+    android:padding="@dimen/settings_list_item_inner_padding">
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
+
+        <TextView
+            android:id="@+id/view_preference_checkbox_seeding_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="2"
+            android:text="@string/dummy_title"
+            android:textColor="@color/disabled_text_selector"
+            android:textSize="@dimen/text_medium" />
+
+        <TextView
+            android:id="@+id/view_preference_checkbox_seeding_summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/view_preference_checkbox_seeding_title"
+            android:maxLines="3"
+            android:text="@string/dummy_summary"
+            android:textColor="@color/disabled_text_selector"
+            android:textSize="@dimen/text_size_small" />
+
+    </RelativeLayout>
+
+    <!-- Preference should place its actual preference widget here. -->
+    <LinearLayout
+        android:id="@+id/widget_frame"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <CheckBox
+            android:id="@+id/view_preference_checkbox_seeding_checkbox"
+            style="@style/PreferencesCheckboxStyle"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/android/res/values/dimens.xml
+++ b/android/res/values/dimens.xml
@@ -43,4 +43,7 @@
 
     <dimen name="dialog_min_width_major">200dp</dimen>
     <dimen name="dialog_min_width_minor">300dp</dimen>
+
+    <!-- Settings -->
+    <dimen name="settings_list_item_inner_padding">16dp</dimen>
 </resources>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -658,4 +658,5 @@
     <string name="frostwire_sticker_and_more">FrostWire stickers and more</string>
     <string name="donate_your_time">Donate your time</string>
     <string name="changelog">Changelog</string>
+    <string name="pro">PRO</string>
 </resources>

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -21,7 +21,11 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="Theme.FrostWire" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">@color/basic_blue</item>
         <item name="colorPrimaryDark">@android:color/black</item>
+        <item name="colorAccent">@color/basic_blue_darker_highlight</item>
+        <item name="android:textColorPrimary">@color/app_text_primary</item>
+        <item name="android:textColorSecondary">@color/app_text_secondary</item>
         <item name="toolbarNavigationButtonStyle">@style/ToolbarNavigationButtonStyle</item>
         <item name="toolbarStyle">@style/ToolbarStyle</item>
     </style>

--- a/android/res/xml/settings_application.xml
+++ b/android/res/xml/settings_application.xml
@@ -26,7 +26,6 @@
         <!--  Wi-Fi Networks Only should replace Use 3G/4G for BitTorrent -->
         <!--<CheckBoxPreference-->
             <!--android:key="frostwire.prefs.network.use_mobile_data"-->
-            <!--android:layout="@layout/view_preference_simple_action"-->
             <!--android:summary="@string/use_mobile_data_summary"-->
             <!--android:title="@string/use_mobile_data" />-->
         <SwitchPreference
@@ -57,7 +56,8 @@
             android:title="@string/notification_other_header" />
         <Preference
             android:summary="@string/remove_ads_description"
-            android:title="@string/remove_ads">
+            android:title="@string/remove_ads"
+            android:layout="@layout/view_preference_buy_ads_2">
             <intent
                 android:action="android.intent.action.VIEW"
                 android:targetClass="com.frostwire.android.gui.activities.BuyActivity"

--- a/android/src/com/frostwire/android/gui/views/preference/ButtonActionPreference.java
+++ b/android/src/com/frostwire/android/gui/views/preference/ButtonActionPreference.java
@@ -80,6 +80,9 @@ public class ButtonActionPreference extends Preference {
 
     @Override
     protected View onCreateView(ViewGroup parent) {
+
+        //for the SettingsActivity2 we will use current
+        // View v = View.inflate(getContext(), R.layout.view_preference_button_action_2, null);
         View v = View.inflate(getContext(), R.layout.view_preference_button_action, null);
 
         textTitle = (TextView) v.findViewById(R.id.view_preference_button_action_title);

--- a/android/src/com/frostwire/android/gui/views/preference/CheckBoxSeedingPreference.java
+++ b/android/src/com/frostwire/android/gui/views/preference/CheckBoxSeedingPreference.java
@@ -41,6 +41,9 @@ public class CheckBoxSeedingPreference extends android.preference.CheckBoxPrefer
 
     @Override
     protected View onCreateView(ViewGroup parent) {
+
+        //for the SettingsActivity2 we will use current
+        // View view = View.inflate(getContext(), R.layout.view_preference_checkbox_seeding_2, null);
         View view = View.inflate(getContext(), R.layout.view_preference_checkbox_seeding, null);
         title = (TextView) view.findViewById(R.id.view_preference_checkbox_seeding_title);
         summary = (TextView) view.findViewById(R.id.view_preference_checkbox_seeding_summary);


### PR DESCRIPTION
@aldenml styling and adjustments to layouts are complete. I added proper colors to material theme (notice that there is no separate style for preference activity like before - less to maintain)

new layouts such as view_preference_button_action_2.xml - are added for later and will replace view_preference_button_action.xml we have currently - as this layout is active now with original settings activity. 

Next steps:
1. work on making preferences functional ( with @grzesiekrzaca ):
    a) BitTorrent connection, Wifi networks only, Select Storage
        @gubatron - remember talking over the new layouts in Denver? We wanted to replace 'Use 3G/4G for BitTorrent' for 'Wi-Fi Networks Only' where cloud downloads are included in the setting. 
Do you have any comments/pointers for me and @grzesiekrzaca ? 
    b) Toggle state and search settings
    c) Torrent preferences
    d) Other
2. work on the single and double pane view of settings based on screen size

Currently:
![screenshot_20161214-185431](https://cloud.githubusercontent.com/assets/2339972/21207760/0a865ca8-c238-11e6-8d40-3c1f299679ad.png)
![screenshot_20161214-185435](https://cloud.githubusercontent.com/assets/2339972/21207761/0a878632-c238-11e6-9364-ff90ffdbf9a7.png)