### PR TITLE
[android] make checked listener in abstract list adapter operate on items instead of views.

### DIFF
--- a/android/src/com/frostwire/android/gui/dialogs/AbstractConfirmListDialog.java
+++ b/android/src/com/frostwire/android/gui/dialogs/AbstractConfirmListDialog.java
@@ -54,7 +54,7 @@ import java.util.*;
  *
  */
 abstract class AbstractConfirmListDialog<T> extends AbstractDialog implements
-        AbstractListAdapter.OnItemCheckedListener {
+        AbstractListAdapter.OnItemCheckedListener<T> {
     static final String BUNDLE_KEY_CHECKED_OFFSETS = "checkedOffsets";
     static final String BUNDLE_KEY_LAST_SELECTED_RADIO_BUTTON_INDEX = "lastSelectedRadioButtonIndex";
     private static final Logger LOG = Logger.getLogger(AbstractConfirmListDialog.class);
@@ -425,7 +425,7 @@ abstract class AbstractConfirmListDialog<T> extends AbstractDialog implements
 
     // AbstractListAdapter.OnItemCheckedListener.onItemChecked(CompoundButton v, boolean checked)
     @Override
-    public void onItemChecked(CompoundButton v, boolean checked) {
+    public void onItemChecked(T item, boolean checked) {
         if (selectionMode == SelectionMode.MULTIPLE_SELECTION) {
             updateSelectedCount();
         }

--- a/android/src/com/frostwire/android/gui/dialogs/AbstractConfirmListDialog.java
+++ b/android/src/com/frostwire/android/gui/dialogs/AbstractConfirmListDialog.java
@@ -425,7 +425,7 @@ abstract class AbstractConfirmListDialog<T> extends AbstractDialog implements
 
     // AbstractListAdapter.OnItemCheckedListener.onItemChecked(CompoundButton v, boolean checked)
     @Override
-    public void onItemChecked(T item, boolean checked) {
+    public void onItemChecked(CompoundButton v, T item, boolean checked) {
         if (selectionMode == SelectionMode.MULTIPLE_SELECTION) {
             updateSelectedCount();
         }

--- a/android/src/com/frostwire/android/gui/views/AbstractListAdapter.java
+++ b/android/src/com/frostwire/android/gui/views/AbstractListAdapter.java
@@ -58,7 +58,7 @@ public abstract class AbstractListAdapter<T> extends BaseAdapter implements Filt
     private final CheckboxOnCheckedChangeListener checkboxOnCheckedChangeListener;
     private int lastSelectedRadioButtonIndex = -1;
     private final RadioButtonOnCheckedChangeListener radioButtonCheckedChangeListener;
-    private OnItemCheckedListener onItemCheckedListener;
+    private OnItemCheckedListener<T> onItemCheckedListener;
 
     private ListAdapterFilter<T> filter;
     private boolean checkboxesVisibility;
@@ -374,7 +374,7 @@ public abstract class AbstractListAdapter<T> extends BaseAdapter implements Filt
         notifyDataSetInvalidated();
 
         if (onItemCheckedListener != null) {
-            onItemCheckedListener.onItemChecked(v, isChecked);
+            onItemCheckedListener.onItemChecked((T) v.getTag(), isChecked);
         }
     }
 
@@ -515,11 +515,11 @@ public abstract class AbstractListAdapter<T> extends BaseAdapter implements Filt
         return null;
     }
 
-    public interface OnItemCheckedListener {
-        void onItemChecked(CompoundButton v, boolean checked);
+    public interface OnItemCheckedListener<T> {
+        void onItemChecked(T item, boolean checked);
     }
 
-    public void setOnItemCheckedListener(OnItemCheckedListener onItemCheckedListener) {
+    public void setOnItemCheckedListener(OnItemCheckedListener<T> onItemCheckedListener) {
         this.onItemCheckedListener = onItemCheckedListener;
     }
 

--- a/android/src/com/frostwire/android/gui/views/AbstractListAdapter.java
+++ b/android/src/com/frostwire/android/gui/views/AbstractListAdapter.java
@@ -374,7 +374,7 @@ public abstract class AbstractListAdapter<T> extends BaseAdapter implements Filt
         notifyDataSetInvalidated();
 
         if (onItemCheckedListener != null) {
-            onItemCheckedListener.onItemChecked((T) v.getTag(), isChecked);
+            onItemCheckedListener.onItemChecked(v, (T) v.getTag(), isChecked);
         }
     }
 
@@ -516,7 +516,7 @@ public abstract class AbstractListAdapter<T> extends BaseAdapter implements Filt
     }
 
     public interface OnItemCheckedListener<T> {
-        void onItemChecked(T item, boolean checked);
+        void onItemChecked(CompoundButton v, T item, boolean checked);
     }
 
     public void setOnItemCheckedListener(OnItemCheckedListener<T> onItemCheckedListener) {


### PR DESCRIPTION
Related to #293 
So I needed an information for the adapter that the item check state was changed so that the logic of check all box could work. Due to the fact that we can check an item without using the check box but any part of the item (on that branch in check mode) it would be hard to find the checkbox without some .getParent() conga line. I really did not need the exact item because all I needed was the info that any item was passed, so I could have passed a null but that somehow did not seem clean. So I thought why not make the adapter return the item itself rather than a CompundButton with the item as a tag.  