### PR TITLE
[android] internal build variable (for consuming purchases) to false

### DIFF
--- a/android/src/com/frostwire/android/gui/activities/SettingsActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/SettingsActivity.java
@@ -78,7 +78,7 @@ import java.util.Map;
  */
 public class SettingsActivity extends PreferenceActivity {
     private static final Logger LOG = Logger.getLogger(SettingsActivity.class);
-    private static final boolean INTERNAL_BUILD = true;
+    private static final boolean INTERNAL_BUILD = false;
     private static String currentPreferenceKey = null;
     private boolean finishOnBack = false;
     private long removeAdsPurchaseTime = 0;


### PR DESCRIPTION
This allows user if set to true to delete their onetime purchase after clicking it 20 times. Probably should be set to false. 