### PR TITLE
[android] fixed styling and padding on API 17-19

### DIFF
--- a/android/res/layout/view_preference_category_material.xml
+++ b/android/res/layout/view_preference_category_material.xml
@@ -22,8 +22,7 @@
     android:layout_height="wrap_content"
     android:layout_marginBottom="16dip"
     android:textAppearance="@style/Preference_TextAppearanceMaterialBody2"
-    android:textColor="@color/basic_blue_darker_highlight"
-    android:textStyle="bold"
+    style="@style/Preference.Category.Material"
     android:paddingLeft="?android:attr/listPreferredItemPaddingLeft"
     android:paddingRight="?android:attr/listPreferredItemPaddingRight"
     android:paddingTop="16dip" />

--- a/android/res/values-v17/themes.xml
+++ b/android/res/values-v17/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="PreferenceThemeOverlay" parent="PreferenceThemeOverlay.v14.Material">
+        <item name="android:listPreferredItemPaddingEnd">16dp</item>
+        <item name="android:listPreferredItemPaddingStart">16dp</item>
+    </style>
+</resources>

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -28,11 +28,17 @@
         <item name="android:textColorSecondary">@color/app_text_secondary</item>
         <item name="toolbarNavigationButtonStyle">@style/ToolbarNavigationButtonStyle</item>
         <item name="toolbarStyle">@style/ToolbarStyle</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+    </style>
+
+    <style name="PreferenceThemeOverlay" parent="PreferenceThemeOverlay.v14.Material">
+        <item name="preferenceCategoryStyle">@style/Preference.Category.Material</item>
     </style>
 
     <style name="Preference.Category.Material">
         <item name="android:layout">@layout/view_preference_category_material</item>
+        <item name="android:textColor">@color/basic_blue_darker_highlight</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Theme.FrostWire.NoMaterial" parent="android:Theme.Holo.Light">


### PR DESCRIPTION
@aldenml I know it is adding a new v-17 themes file - but it is the most straightforward solution I found to control the paddings of the list in preferences. Below are before screenshots from api17, 18,19. 
API 16 was good with only the layout. Let me know if we can keep it. 

<img width="490" alt="screen shot 2017-01-24 at 8 21 07 am" src="https://cloud.githubusercontent.com/assets/2339972/22255209/e0d248e4-e213-11e6-85b6-37a735a475b5.png">
<img width="489" alt="screen shot 2017-01-24 at 8 34 41 am" src="https://cloud.githubusercontent.com/assets/2339972/22255217/e6064414-e213-11e6-8adf-b89bc56eab3b.png">
<img width="485" alt="screen shot 2017-01-24 at 8 32 16 am" src="https://cloud.githubusercontent.com/assets/2339972/22255218/e9254398-e213-11e6-8199-c7031d93dba5.png">
