### PR TITLE
[android] fix crash due to old class ref

### DIFF
--- a/android/res/xml/settings_other.xml
+++ b/android/res/xml/settings_other.xml
@@ -43,7 +43,7 @@
         android:key="frostwire.prefs.uxstats.enabled"
         android:summary="@string/anonymous_usage_statistics_summary"
         android:title="@string/anonymous_usage_statistics" />
-    <com.frostwire.android.gui.views.preference.ButtonActionPreference2
+    <com.frostwire.android.gui.views.preference.ButtonActionPreference
         android:key="frostwire.prefs.internal.clear_index"
         android:summary="@string/clear_search_cache_summary"
         android:title="@string/clear_search_cache"


### PR DESCRIPTION
this fixes crash introduced in 
https://github.com/frostwire/frostwire/commit/4ceac17a8e6bc5d21f0be5be3420bd2007b128bb
due to renaming of `ButtonActionPreference2` to `ButtonActionPreference`