### PR TITLE
[android] added missing background color for the search progress

### DIFF
--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -125,6 +125,7 @@
         <item name="android:indeterminateDrawable">
             @drawable/progress_indeterminate_horizontal_holo
         </item>
+        <item name="android:background">@color/basic_blue</item>
         <item name="android:minHeight">16dip</item>
         <item name="android:maxHeight">16dip</item>
     </style>


### PR DESCRIPTION
Tiny change. The background was lost and it was white.