### PR TITLE
[android] dont reinflate the fragment header when syncing the menu.

### DIFF
--- a/android/src/com/frostwire/android/gui/activities/MainActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/MainActivity.java
@@ -660,7 +660,6 @@ public class MainActivity extends AbstractActivity implements ConfigurationUpdat
             menuId = R.id.menu_main_transfers;
         }
         setCheckedItem(menuId);
-        updateHeader(getCurrentFragment());
     }
 
     private void setCheckedItem(int id) {


### PR DESCRIPTION
This is not really needed and lead to a quite heavy Toolbar in new `BrowsePeerFragment` beeing reinflated multiple times when closing/opening the drawer. 