### PR TITLE
[android] Solving equalizer doesn't appear in player activity

### DIFF
--- a/android/apollo/src/com/andrew/apollo/utils/NavUtils.java
+++ b/android/apollo/src/com/andrew/apollo/utils/NavUtils.java
@@ -95,7 +95,8 @@ public final class NavUtils {
         try {
             final Intent effects = new Intent(AudioEffect.ACTION_DISPLAY_AUDIO_EFFECT_CONTROL_PANEL);
             effects.putExtra(AudioEffect.EXTRA_AUDIO_SESSION, MusicUtils.getAudioSessionId());
-            context.startActivity(effects);
+            // No result expected for this activity
+            context.startActivityForResult(effects, 0);
         } catch (final ActivityNotFoundException notFound) {
             AppMsg.makeText(context, context.getString(R.string.no_effects_for_you),
                     AppMsg.STYLE_ALERT);


### PR DESCRIPTION
Issue #357 : 
Just changed the call from ```startActivity``` to ```startActivityForResult``` method. 

The only guess that i have about this issue, it seems to be related to the integer value passed as expected value internally to ```startActivityForResult```.

I checked android ```Activity``` class, found ```startActivity``` calls ```startActivityForResult``` passing a ```-1``` as expected result but if that value is changed by ```0``` (I think we can use any integer) equalizer is showed with no problems

````
    /**
     * Launch a new activity.  You will not receive any information about when
     * the activity exits.  This implementation overrides the base version,
     * providing information about
     * the activity performing the launch.  Because of this additional
     * information, the {@link Intent#FLAG_ACTIVITY_NEW_TASK} launch flag is not
     * required; if not specified, the new activity will be added to the
     * task of the caller.
     *
     * <p>This method throws {@link android.content.ActivityNotFoundException}
     * if there was no Activity found to run the given Intent.
     *
     * @param intent The intent to start.
     * @param options Additional options for how the Activity should be started.
     * See {@link android.content.Context#startActivity(Intent, Bundle)
     * Context.startActivity(Intent, Bundle)} for more details.
     *
     * @throws android.content.ActivityNotFoundException
     *
     * @see #startActivity(Intent)
     * @see #startActivityForResult
     */
    @Override
    public void startActivity(Intent intent, @Nullable Bundle options) {
        if (options != null) {
            startActivityForResult(intent, -1, options);
        } else {
            // Note we want to go through this call for compatibility with
            // applications that may have overridden the method.
            startActivityForResult(intent, -1);
        }
    }
````

![58afc8be4a2fa449978163](https://cloud.githubusercontent.com/assets/368680/23292052/d929930c-fa2a-11e6-8fe3-579cd7cdb555.gif)