### PR TITLE
[android] consistent layouts for recent tab

### DIFF
--- a/android/apollo/src/com/andrew/apollo/ui/fragments/RecentFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/RecentFragment.java
@@ -60,6 +60,8 @@ public final class RecentFragment extends BaseAlbumFragment {
         int layout;
         if (isSimpleLayout()) {
             layout = R.layout.list_item_normal;
+        } else if (isDetailedLayout()) {
+            layout = R.layout.list_item_detailed_no_background;
         } else {
             layout = R.layout.grid_items_normal;
         }


### PR DESCRIPTION
This fixes a problem @marcelinkaaa mentioned on slack - inconsistent way the layouts are shown for the "recent" tab in My Music.