### PR TITLE
[android] adjusted nav_header layout for better performance on small …

### DIFF
--- a/android/res/layout-sw360dp-port/nav_view_header.xml
+++ b/android/res/layout-sw360dp-port/nav_view_header.xml
@@ -20,23 +20,26 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@color/app_toolbar_background"
-    android:orientation="horizontal"
-    android:padding="14dp">
+    android:layout_height="132dp"
+    android:background="@color/basic_blue"
+    android:gravity="bottom"
+    android:orientation="vertical"
+    android:paddingBottom="10dp"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp">
 
     <ImageView
         android:id="@+id/nav_view_header_main_app_logo"
-        android:layout_width="42dp"
-        android:layout_height="42dp"
-        android:layout_gravity="center_vertical"
-        android:layout_marginRight="10dp"
+        android:layout_width="54dp"
+        android:layout_height="54dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="12dp"
         android:src="@drawable/app_icon" />
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center_vertical">
+        android:layout_height="wrap_content"
+        android:gravity="bottom">
 
         <TextView
             android:id="@+id/nav_view_header_main_title"
@@ -54,28 +57,17 @@
             android:id="@+id/nav_view_header_main_version"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/nav_view_header_main_title"
+            android:layout_toRightOf="@+id/nav_view_header_main_title"
             android:text="@string/dummy_title"
-            android:textColor="@color/basic_gray_medium"
-            android:textSize="@dimen/text_size_micro" />
-
-        <TextView
-            android:id="@+id/nav_view_header_main_comma"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/nav_view_header_main_title"
-            android:layout_toRightOf="@+id/nav_view_header_main_version"
-            android:text=","
-            android:textColor="@color/basic_gray_medium"
-            android:textSize="@dimen/text_size_micro" />
+            android:textColor="@color/basic_white"
+            android:textSize="@dimen/text_size_small"
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/nav_view_header_main_build"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@+id/nav_view_header_main_title"
-            android:layout_marginLeft="5dp"
-            android:layout_toRightOf="@+id/nav_view_header_main_comma"
             android:text="@string/dummy_build"
             android:textColor="@color/basic_gray_medium"
             android:textSize="@dimen/text_size_micro" />
@@ -86,15 +78,14 @@
             android:layout_height="20dp"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_gravity="center_vertical"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="10dp"
             android:background="@color/transparent"
             android:clickable="true"
             android:elevation="1dp"
             android:gravity="end"
             android:src="@drawable/menu_update"
-            android:tint="@color/basic_green"
-            android:visibility="visible" />
+            android:tint="@color/basic_green" />
+
 
     </RelativeLayout>
 

--- a/android/res/layout/nav_view_header.xml
+++ b/android/res/layout/nav_view_header.xml
@@ -19,50 +19,24 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="132dp"
-              android:background="@color/basic_blue"
-              android:gravity="bottom"
-              android:orientation="vertical"
-              android:paddingBottom="10dp"
-              android:paddingLeft="16dp"
-              android:paddingRight="16dp" >
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/app_toolbar_background"
+    android:orientation="horizontal"
+    android:padding="14dp">
 
     <ImageView
         android:id="@+id/nav_view_header_main_app_logo"
-        android:layout_width="54dp"
-        android:layout_height="54dp"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginBottom="12dp"
+        android:layout_width="42dp"
+        android:layout_height="42dp"
+        android:layout_gravity="center_vertical"
+        android:layout_marginRight="10dp"
         android:src="@drawable/app_icon" />
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="bottom">
-
-        <TextView
-            android:id="@+id/nav_view_header_main_build"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/nav_view_header_main_title"
-            android:text="@string/dummy_build"
-            android:textColor="@color/basic_gray_medium"
-            android:textSize="@dimen/text_size_micro" />
-
-        <ImageView
-            android:id="@+id/nav_view_header_main_update"
-            android:layout_width="20dp"
-            android:layout_height="20dp"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_marginTop="10dp"
-            android:background="@color/transparent"
-            android:elevation="1dp"
-            android:gravity="end"
-            android:src="@drawable/menu_update"
-            android:tint="@color/basic_green"
-            android:clickable="true"/>
+        android:layout_height="match_parent"
+        android:gravity="center_vertical">
 
         <TextView
             android:id="@+id/nav_view_header_main_title"
@@ -75,6 +49,53 @@
             android:textColor="@color/basic_white"
             android:textSize="@dimen/text_size_small"
             android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/nav_view_header_main_version"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/nav_view_header_main_title"
+            android:text="@string/dummy_title"
+            android:textColor="@color/basic_gray_medium"
+            android:textSize="@dimen/text_size_micro" />
+
+        <TextView
+            android:id="@+id/nav_view_header_main_comma"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/nav_view_header_main_title"
+            android:layout_toRightOf="@+id/nav_view_header_main_version"
+            android:text=","
+            android:textColor="@color/basic_gray_medium"
+            android:textSize="@dimen/text_size_micro" />
+
+        <TextView
+            android:id="@+id/nav_view_header_main_build"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/nav_view_header_main_title"
+            android:layout_marginLeft="5dp"
+            android:layout_toRightOf="@+id/nav_view_header_main_comma"
+            android:text="@string/dummy_build"
+            android:textColor="@color/basic_gray_medium"
+            android:textSize="@dimen/text_size_micro" />
+
+        <ImageView
+            android:id="@+id/nav_view_header_main_update"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_gravity="center_vertical"
+            android:layout_marginTop="8dp"
+            android:background="@color/transparent"
+            android:clickable="true"
+            android:elevation="1dp"
+            android:gravity="end"
+            android:src="@drawable/menu_update"
+            android:tint="@color/basic_green"
+            android:visibility="visible" />
+
     </RelativeLayout>
 
 </LinearLayout>

--- a/android/res/layout/view_ad_menuitem.xml
+++ b/android/res/layout/view_ad_menuitem.xml
@@ -29,8 +29,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
+        android:layout_marginTop="22dp"
         android:layout_toLeftOf="@+id/view_ad_menu_item_thumbnail"
-        android:layout_marginTop="30dp"
         android:paddingLeft="12dp">
 
         <TextView
@@ -38,9 +38,9 @@
             style="@style/SlideMenuAdHeader"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/support_frostwire"
+            android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
-            android:layout_alignParentLeft="true" />
+            android:text="@string/support_frostwire" />
 
         <TextView
             android:id="@+id/view_ad_menu_item_subtitle"

--- a/android/src/com/frostwire/android/gui/activities/internal/NavigationMenu.java
+++ b/android/src/com/frostwire/android/gui/activities/internal/NavigationMenu.java
@@ -110,8 +110,10 @@ public final class NavigationMenu {
             View navViewHeader = resultNavView.getHeaderView(0);
             // Prep title and version
             TextView title = (TextView) navViewHeader.findViewById(R.id.nav_view_header_main_title);
+            TextView version = (TextView) navViewHeader.findViewById(R.id.nav_view_header_main_version);
             String basicOrPlus = (String) activity.getText(Constants.IS_GOOGLE_PLAY_DISTRIBUTION ? R.string.basic : R.string.plus);
-            title.setText(activity.getText(R.string.application_label) + " " + basicOrPlus + " v" + Constants.FROSTWIRE_VERSION_STRING);
+            title.setText(activity.getText(R.string.application_label) + " " + basicOrPlus);
+            version.setText(" v" + Constants.FROSTWIRE_VERSION_STRING);
             TextView build = (TextView) navViewHeader.findViewById(R.id.nav_view_header_main_build);
             build.setText(activity.getText(R.string.build) + " " + BuildConfig.VERSION_CODE);
             // Prep update button


### PR DESCRIPTION
…screens

Decided to add one more layout (layout-sw-360dp-port) - this layout will only be displayed on devices with a viewport width larger thAn 360 - so basically Nexus 5 and larger screens. Regular layout will be displayed for all other smaller screen. The menu should be now fully visible vertically on all (hopefully) devices.

I also changed landscape layout a bit so that it includes our logo. 

<img width="480" alt="screen shot 2017-03-09 at 11 34 54 am" src="https://cloud.githubusercontent.com/assets/2339972/23765234/c688b83e-04bd-11e7-8bf5-abae9a920b33.png">
<img width="802" alt="screen shot 2017-03-09 at 11 35 04 am" src="https://cloud.githubusercontent.com/assets/2339972/23765232/c687df36-04bd-11e7-9fe7-ca0a524f2a98.png">
<img width="422" alt="screen shot 2017-03-09 at 11 37 28 am" src="https://cloud.githubusercontent.com/assets/2339972/23765235/c68b30a0-04bd-11e7-80c7-6b3ea13d49f2.png">
<img width="735" alt="screen shot 2017-03-09 at 11 37 38 am" src="https://cloud.githubusercontent.com/assets/2339972/23765233/c688a84e-04bd-11e7-9d50-cf3ec55b4c43.png">
