### PR TITLE
[android] fix for ad-view overlaying on top of the menu

### DIFF
--- a/android/res/layout/view_ad_menuitem.xml
+++ b/android/res/layout/view_ad_menuitem.xml
@@ -29,7 +29,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
-        android:layout_marginTop="22dp"
+        android:layout_marginTop="20dp"
         android:layout_toLeftOf="@+id/view_ad_menu_item_thumbnail"
         android:paddingLeft="12dp">
 

--- a/android/res/menu/nav_view_menu.xml
+++ b/android/res/menu/nav_view_menu.xml
@@ -48,5 +48,13 @@
             android:id="@+id/menu_main_shutdown"
             android:icon="@drawable/menu_icon_exit"
             android:title="Exit"/>
+
+        <item
+            android:id="@+id/menu_main_footer_spacer_1"
+            android:checkable="false"
+            android:enabled="false"
+            android:orderInCategory="200"
+            android:title="" />
+
     </group>
 </menu>


### PR DESCRIPTION
Currently the navigation drawer ad is overlapping the menu, which causes the last menu item - "Exit" to be hidden under the ad itself. 
There is a few hacky ways to do it with layouts/paddings but they are a bit too much. This was the simplest way to accomplish it. 
I am not sure how to do it any other way. If you have any pointers I will be happy to give them a go. 

<img width="800" alt="screen shot 2017-03-09 at 2 36 01 pm" src="https://cloud.githubusercontent.com/assets/2339972/23771833/f2d565c8-04d5-11e7-862e-0166fa4150a8.png">
<img width="801" alt="screen shot 2017-03-09 at 2 36 54 pm" src="https://cloud.githubusercontent.com/assets/2339972/23771832/f2d4223a-04d5-11e7-9c67-f00c3c4d8253.png">
