### PR TITLE
Fixes broken link on Language change

### DIFF
--- a/desktop/src/com/limegroup/gnutella/gui/LanguageWindow.java
+++ b/desktop/src/com/limegroup/gnutella/gui/LanguageWindow.java
@@ -34,7 +34,7 @@ public class LanguageWindow extends JDialog {
 
     private static final int MIN_DIALOG_WIDTH = 350;
 
-    private static final String TRANSLATE_URL = "https://github.com/frostwire/frostwire-desktop";
+    private static final String TRANSLATE_URL = "https://github.com/frostwire/frostwire";
 
     private JCheckBox showLanguageCheckbox;
 


### PR DESCRIPTION
This is a minor issue when trying to change the Language from the 'flag' icon at the bottom bar, the Language-Window has a link 'Help to translate FrostWire' that was pointing the old frostwire-desktop repo. I didn't open an issue because is a tiny thing.