### PR TITLE
[android] fixed settings-search engines padding

### DIFF
--- a/android/res/layout/view_preference_search_engine.xml
+++ b/android/res/layout/view_preference_search_engine.xml
@@ -24,9 +24,7 @@
     android:clipToPadding="false"
     android:focusable="true"
     android:gravity="center_vertical"
-    android:minHeight="?android:attr/listPreferredItemHeightSmall"
-    android:paddingLeft="?android:attr/listPreferredItemPaddingLeft"
-    android:paddingRight="?android:attr/listPreferredItemPaddingRight">
+    android:minHeight="?android:attr/listPreferredItemHeightSmall" >
 
 
     <LinearLayout
@@ -39,6 +37,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:paddingBottom="16dp"
+            android:paddingLeft="@dimen/settings_list_item_inner_horizontal_padding"
             android:paddingTop="16dp">
 
             <TextView
@@ -46,7 +45,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:ellipsize="marquee"
-                android:singleLine="true"
+                android:maxLines="1"
                 android:textAppearance="@style/Preference_TextAppearanceMaterialSubhead" />
 
             <TextView
@@ -68,7 +67,8 @@
             android:layout_height="match_parent"
             android:gravity="end|center_vertical"
             android:orientation="vertical"
-            android:paddingLeft="16dp" />
+            android:paddingLeft="@dimen/settings_list_item_inner_horizontal_padding"
+            android:paddingRight="@dimen/settings_list_item_inner_horizontal_padding" />
 
     </LinearLayout>
 </LinearLayout>

--- a/android/res/values/dimens.xml
+++ b/android/res/values/dimens.xml
@@ -51,5 +51,5 @@
     <dimen name="dialog_min_width_minor">300dp</dimen>
 
     <!-- Settings -->
-    <dimen name="settings_list_item_inner_padding">16dp</dimen>
+    <dimen name="settings_list_item_inner_horizontal_padding">16dp</dimen>
 </resources>


### PR DESCRIPTION
android:paddingLeft in the top layout was not working properly on API 16-19 - had to apply padding on its children instead

<img width="469" alt="screen shot 2017-03-18 at 7 03 37 pm" src="https://cloud.githubusercontent.com/assets/2339972/24077439/dee22ed6-0c12-11e7-926a-37c2d5f7e7f6.png">
