### PR TITLE
[android] overflow menu fix in apollo

### DIFF
--- a/android/res/menu/player_add_to_homescreen.xml
+++ b/android/res/menu/player_add_to_homescreen.xml
@@ -25,6 +25,6 @@
         android:icon="@drawable/ic_action_pinn_to_home"
         android:orderInCategory="2"
         android:title="@string/menu_add_to_homescreen"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
 </menu>

--- a/android/res/menu/player_favorite.xml
+++ b/android/res/menu/player_favorite.xml
@@ -25,6 +25,6 @@
         android:icon="@drawable/ic_action_favorite"
         android:orderInCategory="2"
         android:title="@string/add_to_favorites"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
 </menu>

--- a/android/res/menu/player_search.xml
+++ b/android/res/menu/player_search.xml
@@ -26,6 +26,6 @@
         android:orderInCategory="1"
         android:title="@string/menu_search"
         app:actionViewClass="android.support.v7.widget.SearchView"
-        app:showAsAction="ifRoom|collapseActionView" />
+        app:showAsAction="always|collapseActionView" />
 
 </menu>


### PR DESCRIPTION
Test case: 
1. My Music -> 2. Albums (check what icon appear on the toolbar and what appears on overflow menu) -> 3. click on search icon (check what icon appear on the toolbar and check what appears on overflow menu)

When you click on search icon - you can see 'Add to favorites' twice - once in the toolbar as an icon and then in the overflow menu. Also you are already in the search mode - yet you still see 'search' as an option in the overflow menu, which does not do anything other then returning you to the same screen. By changing app:showAsAction="ifRoom" to app:showAsAction="always” I only show the icons in the toolbar without the repetition. This will, however, force the favorites icon to be in the toolbar (and not only in the overflow menu) on smaller screen devices - I have tested on smaller screen devices and this change still looks good. 

PS: we should also hide 'Add to favorites' icon when it is disabled, meaning when the player is off. The icon is always present even if you are on the screen when you can not favorite anything. 
I tried to do it but I am not sure how to write a function that will check if the player is running or not and then connect it to the icon. Could someone help? 

![context_menu](https://cloud.githubusercontent.com/assets/2339972/24276986/fd52bcbe-0fff-11e7-8a3f-1d67e542b74f.jpg)


