### PR TITLE
[android] Fixes file opening issues for default storage

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -302,5 +302,15 @@
             android:configChanges="keyboardHidden|orientation|screenSize" />
         <activity android:name="com.mopub.mobileads.RewardedMraidActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"/>
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 </manifest>

--- a/android/res/xml/provider_paths.xml
+++ b/android/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>

--- a/android/res/xml/provider_paths.xml
+++ b/android/res/xml/provider_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="external_files" path="."/>
+    <root-path name="external_files" path="/storage/" />
 </paths>

--- a/android/src/com/frostwire/android/gui/util/UIUtils.java
+++ b/android/src/com/frostwire/android/gui/util/UIUtils.java
@@ -20,8 +20,10 @@ package com.frostwire.android.gui.util;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.Application;
 import android.app.Dialog;
 import android.content.ActivityNotFoundException;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
@@ -30,6 +32,7 @@ import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Looper;
 import android.support.design.widget.Snackbar;
+import android.support.v4.content.FileProvider;
 import android.text.Html;
 import android.util.DisplayMetrics;
 import android.view.Gravity;
@@ -46,6 +49,7 @@ import android.widget.ListView;
 import android.widget.Toast;
 
 import com.andrew.apollo.utils.MusicUtils;
+import com.frostwire.android.BuildConfig;
 import com.frostwire.android.R;
 import com.frostwire.android.core.ConfigurationManager;
 import com.frostwire.android.core.Constants;
@@ -329,8 +333,10 @@ public final class UIUtils {
         try {
             if (filePath != null && !openAudioInternal(filePath)) {
                 Intent i = new Intent(Intent.ACTION_VIEW);
-                i.setDataAndType(Uri.fromFile(new File(filePath)), mime);
-                i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                //Uri uri = Uri.fromFile(new File(filePath));
+                Uri uri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", new File(filePath));
+                i.setDataAndType(uri, Intent.normalizeMimeType(mime));
+                i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
                 if (mime != null && mime.contains("video")) {
                     if (MusicUtils.isPlaying()) {
@@ -338,7 +344,7 @@ public final class UIUtils {
                     }
                     UXStats.instance().log(UXAction.LIBRARY_VIDEO_PLAY);
                 }
-
+                context.grantUriPermission(context.getPackageName(), uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
                 context.startActivity(i);
             }
         } catch (Throwable e) {


### PR DESCRIPTION
It seems that after SDK 24 we cannot pass a file:// URI to another app via Intent data
since all the permissions to interact with such file are a responsability of our app
android now decided we need to have a content provider for the files we send to other intents

This is working so far for our default save location, but it's problematic when the user
changes the default save location to say an external storage device since the FileProvider
documentation says that we must provide the directories before-hand when we declare
the provider in the manifest.

it is my hope that we'll find a way to manipulate such paths programatically somehow. Perhaps
you've read about this already @aldenml