### PR TITLE
[android] expand horizontal preview view when no ads are displayed

### DIFF
--- a/android/src/com/frostwire/android/gui/activities/PreviewPlayerActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/PreviewPlayerActivity.java
@@ -685,8 +685,10 @@ public final class PreviewPlayerActivity extends AbstractActivity implements
     }
 
     private void hideHorizontalAdContainer() {
-        LinearLayout horizontalAdContainer = findView(R.id.activity_preview_player_right_side);
-        horizontalAdContainer.setVisibility(View.GONE);
+        if (!isPortrait) {
+            LinearLayout horizontalAdContainer = findView(R.id.activity_preview_player_right_side);
+            horizontalAdContainer.setVisibility(View.GONE);
+        }
     }
     
     @Override

--- a/android/src/com/frostwire/android/gui/activities/PreviewPlayerActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/PreviewPlayerActivity.java
@@ -207,7 +207,7 @@ public final class PreviewPlayerActivity extends AbstractActivity implements
 
     private void initMopubView() {
         if (Offers.disabledAds()) {
-            // TODO: Load some place holder graphic for users that already paid to remove ads
+            hideHorizontalAdContainer();
             return;
         }
         final int mopubPreviewBannerThreshold = ConfigurationManager.instance().getInt(Constants.PREF_KEY_GUI_MOPUB_PREVIEW_BANNER_THRESHOLD);
@@ -252,7 +252,7 @@ public final class PreviewPlayerActivity extends AbstractActivity implements
                 if (!Offers.disabledAds()) {
                     // TODO: Replace with hardcoded house ads for donations, stickers, fw gear
                 } else {
-                    // TODO: Load some place holder graphic for users that already paid to remove ads
+                    hideHorizontalAdContainer();
                 }
             }
 
@@ -403,6 +403,8 @@ public final class PreviewPlayerActivity extends AbstractActivity implements
             setViewsVisibility(View.VISIBLE, playerMetadataHeader, downloadButton, rightSide);
             if (mopubLoaded) {
                 setViewsVisibility(View.VISIBLE, advertisementHeaderLayout, moPubView);
+            } else {
+                hideHorizontalAdContainer();
             }
             v.setRotation(0);
 
@@ -674,6 +676,7 @@ public final class PreviewPlayerActivity extends AbstractActivity implements
                 LinearLayout advertisementHeaderLayout = findView(R.id.activity_preview_advertisement_header_layout);
                 advertisementHeaderLayout.setVisibility(View.GONE);
                 mopubView.setVisibility(View.GONE);
+                hideHorizontalAdContainer();
                 mopubView.destroy(); // -> mopubView.unregisterScreenStateBroadcastReceiver() private method call
             }
         } catch (Throwable ignored) {
@@ -681,6 +684,11 @@ public final class PreviewPlayerActivity extends AbstractActivity implements
         }
     }
 
+    private void hideHorizontalAdContainer() {
+        LinearLayout horizontalAdContainer = findView(R.id.activity_preview_player_right_side);
+        horizontalAdContainer.setVisibility(View.GONE);
+    }
+    
     @Override
     protected void onStop() {
         super.onStop();


### PR DESCRIPTION
@gubatron I am expanding the horizontal preview to the width of the screen when no ads on the right side are being loaded, or a user paid for the no-ad version. 
Of course that can be later modified if you set up the logic to fill in our own placement ads. 
Let me know if it works ok for now. Looks good on my devices. 