### PR TITLE
[android] fixes sizing differences in portrait and landscape mode

### DIFF
--- a/android/res/layout/toolbar_main.xml
+++ b/android/res/layout/toolbar_main.xml
@@ -23,7 +23,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/toolbar_main"
     android:layout_width="match_parent"
-    android:layout_height="54dp"
+    android:layout_height="?attr/actionBarSize"
     android:background="@color/app_toolbar_background"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
     app:popupTheme="@style/ThemeOverlay.AppCompat.Light"


### PR DESCRIPTION
Toolbar heigh changes slightly depending on the devices and portrait/horizontal modes. We kept it set at 54dp, which is good but since the height was not adjusting when switched to horizontal mode the toolbar title was not properly aligned with the icons. As shown on the image (nr.1 is what we have, nr.2 is with adjusted height of the toolbar
![toolbar_sizing](https://cloud.githubusercontent.com/assets/2339972/24885996/f33ce0ac-1e0e-11e7-90a0-18bd915fdef6.jpg)
)