### PR TITLE
[android] added custom horizontal layout for Tabs in Search

### DIFF
--- a/android/res/layout-land/view_searchinput_tablayout.xml
+++ b/android/res/layout-land/view_searchinput_tablayout.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+/*
+* Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+* Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+-->
+<android.support.design.widget.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/view_search_input_tab_layout_file_type"
+    style="@style/AppTabLayout"
+    android:layout_width="match_parent"
+    android:layout_height="45dp"
+    app:tabGravity="fill"
+    app:tabMode="fixed">
+
+    <android.support.design.widget.TabItem
+        android:id="@+id/view_search_input_tab_audio"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:icon="@drawable/browse_peer_audio_icon_tab_selector"
+        android:layout="@layout/view_searchinput_tablayout_custom_tab" />
+
+    <android.support.design.widget.TabItem
+        android:id="@+id/view_search_input_tab_videos"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:icon="@drawable/browse_peer_video_icon_tab_selector"
+        android:layout="@layout/view_searchinput_tablayout_custom_tab" />
+
+    <android.support.design.widget.TabItem
+        android:id="@+id/view_search_input_tab_pictures"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:icon="@drawable/browse_peer_picture_icon_tab_selector"
+        android:layout="@layout/view_searchinput_tablayout_custom_tab" />
+
+    <android.support.design.widget.TabItem
+        android:id="@+id/view_search_input_tab_applications"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:icon="@drawable/browse_peer_application_icon_tab_selector"
+        android:layout="@layout/view_searchinput_tablayout_custom_tab" />
+
+    <android.support.design.widget.TabItem
+        android:id="@+id/view_search_input_tab_documents"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:icon="@drawable/browse_peer_document_icon_tab_selector"
+        android:layout="@layout/view_searchinput_tablayout_custom_tab" />
+
+    <android.support.design.widget.TabItem
+        android:id="@+id/view_search_input_tab_torrents"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:icon="@drawable/browse_peer_torrent_icon_tab_selector"
+        android:layout="@layout/view_searchinput_tablayout_custom_tab" />
+</android.support.design.widget.TabLayout>

--- a/android/res/layout-land/view_searchinput_tablayout_custom_tab.xml
+++ b/android/res/layout-land/view_searchinput_tablayout_custom_tab.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+/*
+* Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+* Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@android:id/icon"
+        android:layout_width="25dp"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="4dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/browse_peer_audio_icon_tab_selector" />
+
+    <TextView
+        android:id="@android:id/text1"
+        style="@style/AppTabTextAppearance"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical|center_horizontal"
+        android:text="Hello" />
+
+</LinearLayout>


### PR DESCRIPTION
preserving vertical space on small devices.
@gubatron should work well now, but that separate horizontal layout for TabLayout was necessary to set the height properly
<img width="543" alt="screen shot 2017-06-06 at 6 41 34 pm" src="https://user-images.githubusercontent.com/2339972/26857524-514db882-4ae8-11e7-8762-1d0328dbc49d.png">
