### PR TITLE
[android] refreshes transfer menu on ‘clearing’ transfer list

### DIFF
--- a/android/src/com/frostwire/android/gui/fragments/BrowsePeerFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/BrowsePeerFragment.java
@@ -806,6 +806,9 @@ public class BrowsePeerFragment extends AbstractFragment implements LoaderCallba
         @Override
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
+            if (context instanceof Activity) {
+                ((Activity) context).invalidateOptionsMenu();
+            }
             if (action.equals(Constants.ACTION_MEDIA_PLAYER_PLAY) ||
                     action.equals(Constants.ACTION_MEDIA_PLAYER_STOPPED) ||
                     action.equals(Constants.ACTION_MEDIA_PLAYER_PAUSED) ||

--- a/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
@@ -102,9 +102,7 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
     private boolean isVPNactive;
     private static boolean firstTimeShown = true;
     private Handler vpnRichToastHandler;
-
     private boolean showTorrentSettingsOnClick;
-
 
     public TransfersFragment() {
         super(R.layout.fragment_transfers);
@@ -142,13 +140,17 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
 
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
-        TransferManager tm = TransferManager.instance();
-        boolean bittorrentDisconnected = tm.isBittorrentDisconnected();
-        final List<Transfer> transfers = tm.getTransfers();
-
         menu.findItem(R.id.fragment_transfers_menu_pause_stop_all).setVisible(false);
         menu.findItem(R.id.fragment_transfers_menu_clear_all).setVisible(false);
         menu.findItem(R.id.fragment_transfers_menu_resume_all).setVisible(false);
+        updateMenuItemVisibility(menu);
+        super.onPrepareOptionsMenu(menu);
+    }
+
+    private void updateMenuItemVisibility(Menu menu) {
+        TransferManager tm = TransferManager.instance();
+        boolean bittorrentDisconnected = tm.isBittorrentDisconnected();
+        final List<Transfer> transfers = tm.getTransfers();
 
         if (transfers != null && transfers.size() > 0) {
             if (someTransfersComplete(transfers)) {
@@ -168,8 +170,6 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
                 menu.findItem(R.id.fragment_transfers_menu_resume_all).setVisible(true);
             }
         }
-
-        super.onPrepareOptionsMenu(menu);
     }
 
     @Override
@@ -180,9 +180,11 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
         switch (item.getItemId()) {
             case R.id.fragment_transfers_menu_add_transfer:
                 toggleAddTransferControls();
+                getActivity().invalidateOptionsMenu();
                 return true;
             case R.id.fragment_transfers_menu_clear_all:
                 TransferManager.instance().clearComplete();
+                getActivity().invalidateOptionsMenu();
                 return true;
             case R.id.fragment_transfers_menu_pause_stop_all:
                 TransferManager.instance().stopHttpTransfers();


### PR DESCRIPTION
Before the overflow menu icon on the toolbar of the transfer screen would only refresh (after clearing all the transfer list items) upon tapping on the menu, or when going to navigation and back, but not while the user stays on the screen and clears the list. 
Therefore the overflow menu icon would stay visible with empty list. 

Added refresh so that the icon updates as the user deletes/clears the transfer list. 

Huge thanks @gubatron 