### PR TITLE
[android] changed add magnet search from a hint to a text

### DIFF
--- a/android/src/com/frostwire/android/gui/fragments/SearchFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/SearchFragment.java
@@ -332,7 +332,7 @@ public final class SearchFragment extends AbstractFragment implements
             searchInput.setText("");
             searchInput.selectTabByMediaType(Constants.FILE_TYPE_VIDEOS);
             performSearch(ytId, Constants.FILE_TYPE_VIDEOS);
-            searchInput.setHint(getActivity().getString(R.string.searching_for) + " youtube:" + ytId);
+            searchInput.setText("youtube:" + ytId);
         }
     }
 


### PR DESCRIPTION
Before when adding magnet/torrent/youtube from a transfer screen you would go automatically to search page. The search bar would contain words that you looked for but it was shown as a hint - therefore no 'x' button to cancel search if it took too long, and upon changing tabs underneath the hint would disappear so the user would not see the search term he/she looked for in the bar anymore. 

Changing the search input from hint to a text makes the text stay in the bar even if tabs are changed and 'x' added for easy exit. 