### PR TITLE
[android] fixed filter tip set up for small devices

### DIFF
--- a/android/res/layout/view_drawer_search_filters.xml
+++ b/android/res/layout/view_drawer_search_filters.xml
@@ -190,11 +190,11 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_weight=".7"
-                        android:paddingBottom="10dp"
+                        android:paddingBottom="8dp"
                         android:paddingEnd="0dp"
                         android:paddingLeft="10dp"
                         android:paddingRight="0dp"
-                        android:paddingStart="10dp"
+                        android:paddingStart="8dp"
                         android:paddingTop="10dp"
                         frostwire:flexWrap="wrap">
 
@@ -204,7 +204,8 @@
                             android:layout_height="wrap_content"
                             android:layout_marginEnd="4dp"
                             android:layout_marginRight="4dp"
-                            android:layout_marginBottom="4dp"
+                            android:paddingBottom="2dp"
+                            android:paddingTop="2dp"
                             android:gravity="center_vertical"
                             android:text="@string/tip_touch_tags_to"
                             android:textColor="@color/app_text_primary"
@@ -213,42 +214,43 @@
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_marginEnd="4dp"
-                            android:layout_marginRight="4dp"
-                            android:background="@drawable/keyword_tag_background_tip_active"
-                            android:orientation="horizontal"
-                            android:paddingBottom="3dp"
-                            android:paddingEnd="8dp"
-                            android:paddingLeft="6dp"
-                            android:paddingRight="8dp"
-                            android:paddingStart="6dp"
-                            android:paddingTop="3dp">
-
-                            <TextView
-                                style="@style/filterTipTagInclusive"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:gravity="center"
-                                android:text="+" />
-
-                            <TextView
-                                style="@style/filterTipTagText"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/include" />
-
-                        </LinearLayout>
-
-                        <LinearLayout
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
                             android:gravity="center_vertical"
+                            android:paddingBottom="2dp"
+                            android:paddingTop="2dp"
                             android:orientation="horizontal">
 
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="4dp"
+                                android:layout_marginRight="4dp"
+                                android:background="@drawable/keyword_tag_background_tip_active"
+                                android:orientation="horizontal"
+                                android:paddingBottom="3dp"
+                                android:paddingEnd="8dp"
+                                android:paddingLeft="6dp"
+                                android:paddingRight="8dp"
+                                android:paddingStart="6dp"
+                                android:paddingTop="3dp">
+
+                                <TextView
+                                    style="@style/filterTipTagInclusive"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:gravity="center"
+                                    android:text="+" />
+
+                                <TextView
+                                    style="@style/filterTipTagText"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/include" />
+
+                            </LinearLayout>
+
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:gravity="center_vertical"
                                 android:text="@string/or"
                                 android:textColor="@color/app_text_primary"
                                 android:textSize="@dimen/text_x_small" />
@@ -289,7 +291,6 @@
                         android:id="@+id/view_drawer_search_filters_touch_tag_tips_close_button"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
-                        android:layout_gravity="center"
                         android:layout_weight=".3"
                         android:background="@null"
                         android:contentDescription="@null"
@@ -297,7 +298,6 @@
                         android:paddingLeft="25dp"
                         android:paddingRight="25dp"
                         android:paddingStart="12dp"
-                        android:layout_marginLeft="75dp"
                         android:src="@drawable/clearable_edittext_clear_icon" />
 
                 </LinearLayout>


### PR DESCRIPTION
Because of the added margin - small screens were pushing content to new line pic.1. Rearranged the layout so that does not happen as on pic.2.

<img width="397" alt="1" src="https://user-images.githubusercontent.com/2339972/27765316-5bdfff80-5e6b-11e7-9563-f6522585978e.png">
<img width="412" alt="2" src="https://user-images.githubusercontent.com/2339972/27765315-5bde0fb8-5e6b-11e7-8428-8cc6974623e9.png">
