### PR TITLE
[android] Move Engine.create() as soon as possible to avoid Runtime Exceptions

### DIFF
--- a/android/src/com/frostwire/android/gui/MainApplication.java
+++ b/android/src/com/frostwire/android/gui/MainApplication.java
@@ -62,6 +62,7 @@ public class MainApplication extends Application {
             installHttpCache();
 
             ConfigurationManager.create(this);
+            Engine.create(this);
 
             Platforms.set(new AndroidPlatform(this));
 
@@ -69,7 +70,6 @@ public class MainApplication extends Application {
 
             NetworkManager.create(this);
             Librarian.create(this);
-            Engine.create(this);
 
             ImageLoader.getInstance(this);
             CrawlPagedWebSearchPerformer.setCache(new DiskCrawlCache(this));


### PR DESCRIPTION
I couldn't find any code where MusicPlaybackService was explicitly started by us.
I'd like to try moving this as  soon as possible to minimize the chance for those Runtime Errors in MusicPlaybackService or anywhere else that might need access to the Engine's Thread Pool