### PR TITLE
added missing include and exclude images into the tip tag

### DIFF
--- a/android/res/drawable/keyword_tag_filter_tip_add.xml
+++ b/android/res/drawable/keyword_tag_filter_tip_add.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ *            Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="0dp"
+        android:left="0dp"
+        android:right="0dp"
+        android:top="0dp">
+        <shape android:shape="oval">
+            <solid android:color="@color/basic_white" />
+            <size
+                android:width="14dp"
+                android:height="14dp" />
+        </shape>
+    </item>
+
+    <item
+        android:left="3dp"
+        android:right="3dp">
+        <shape android:shape="line">
+            <stroke
+                android:width="2dp"
+                android:color="@color/tip_tag_blue" />
+        </shape>
+    </item>
+
+    <item
+        android:left="3dp"
+        android:right="3dp">
+        <rotate
+            android:fromDegrees="90"
+            android:pivotX="50%"
+            android:pivotY="50%"
+            android:toDegrees="-90">
+            <shape android:shape="line">
+                <stroke
+                    android:width="2dp"
+                    android:color="@color/tip_tag_blue" />
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/android/res/drawable/keyword_tag_filter_tip_minus.xml
+++ b/android/res/drawable/keyword_tag_filter_tip_minus.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ *            Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="0dp"
+        android:left="0dp"
+        android:right="0dp"
+        android:top="0dp">
+        <shape android:shape="oval">
+            <solid android:color="@color/basic_white" />
+            <size
+                android:width="14dp"
+                android:height="14dp" />
+        </shape>
+    </item>
+
+    <item
+        android:left="3dp"
+        android:right="3dp">
+        <shape android:shape="line">
+            <stroke
+                android:width="2dp"
+                android:color="@color/tip_tag_blue" />
+        </shape>
+    </item>
+</layer-list>

--- a/android/res/layout/view_drawer_search_filters.xml
+++ b/android/res/layout/view_drawer_search_filters.xml
@@ -225,6 +225,7 @@
                                 android:layout_marginEnd="4dp"
                                 android:layout_marginRight="4dp"
                                 android:background="@drawable/keyword_tag_background_tip_active"
+                                android:gravity="center_vertical"
                                 android:orientation="horizontal"
                                 android:paddingBottom="3dp"
                                 android:paddingEnd="8dp"
@@ -233,12 +234,10 @@
                                 android:paddingStart="6dp"
                                 android:paddingTop="3dp">
 
-                                <TextView
-                                    style="@style/filterTipTagInclusive"
+                                <ImageView
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:gravity="center"
-                                    android:text="+" />
+                                    android:src="@drawable/keyword_tag_filter_tip_add" />
 
                                 <TextView
                                     style="@style/filterTipTagText"
@@ -261,6 +260,7 @@
                                 android:layout_marginLeft="4dp"
                                 android:layout_marginStart="4dp"
                                 android:background="@drawable/keyword_tag_background_tip_active"
+                                android:gravity="center_vertical"
                                 android:orientation="horizontal"
                                 android:paddingBottom="3dp"
                                 android:paddingEnd="8dp"
@@ -269,13 +269,10 @@
                                 android:paddingStart="6dp"
                                 android:paddingTop="3dp">
 
-                                <TextView
-                                    android:id="@+id/textView"
-                                    style="@style/filterTipTagInclusive"
+                                <ImageView
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:gravity="center"
-                                    android:text="-" />
+                                    android:src="@drawable/keyword_tag_filter_tip_minus" />
 
                                 <TextView
                                     style="@style/filterTipTagText"

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -727,11 +727,6 @@
         <item name="android:paddingBottom">15dp</item>
         <item name="android:drawablePadding">15dp</item>
     </style>
-    <style name="filterTipTagInclusive">
-        <item name="android:textStyle">bold</item>
-        <item name="android:textColor">@color/tip_tag_blue</item>
-        <item name="android:textSize">@dimen/text_x_small</item>
-    </style>
     <style name="filterTipTagText">
         <item name="android:textStyle">bold</item>
         <item name="android:textSize">@dimen/text_extra_micro</item>


### PR DESCRIPTION
Alden, in your commit "[android] using layer list drawable for KeywordTagView add/minus" you removed the plus and minus drawables, which I understand the reason for. The white drawable background that was used under the tip tags + and - sign was also removed, hence they became invisible. 

I added the signs the same way you added them for the regular active filter tags. Hope it looks ok. 
![screenshot_20170720-163008](https://user-images.githubusercontent.com/2339972/28441751-91e75cf6-6d69-11e7-937a-d89225fa0ce7.png)
