### PR TITLE
[android] fixed showing of double snackbar on enabling VPN-drop prote…

### DIFF
--- a/android/src/com/frostwire/android/gui/fragments/preference/ApplicationFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/preference/ApplicationFragment.java
@@ -161,6 +161,7 @@ public final class ApplicationFragment extends AbstractPreferenceFragment implem
                 Engine e = Engine.instance();
                 if (e.isStarted() && !newStatus) {
                     disconnect();
+                    UIUtils.showShortMessage(getView(), R.string.toast_on_disconnect);
                 } else if (newStatus && (e.isStopped() || e.isDisconnected())) {
                     if (getPreferenceManager().getSharedPreferences().getBoolean(Constants.PREF_KEY_NETWORK_BITTORRENT_ON_VPN_ONLY, false) &&
                             !NetworkManager.instance().isTunnelUp()) {
@@ -231,7 +232,6 @@ public final class ApplicationFragment extends AbstractPreferenceFragment implem
     private void disconnect() {
         Engine.instance().stopServices(true); // internally this is an async call in libtorrent
         updateConnectSwitchStatus();
-        UIUtils.showShortMessage(getView(), R.string.toast_on_disconnect);
     }
 
     private void updateStorageOptionSummary(String newPath) {


### PR DESCRIPTION
…ction

Previously when in Settings:
When BitTorrent connection status was either on or off and a user tried to enable VPN-Drop Protection - he/she would have a quick glimpse of R.string.toast_on_disconnect snackbar appearing followed by R.string.switch_off_engine_without_vpn snackbar for the VPN-Drop feature, as disconnect(); was called inside setupVPNRequirementOption(). Basically we would show 2 snackbars one after another, but one would be shown for a split second. 