### PR TITLE
[android] Hides filterButton when Connection is down or search brings…

### DIFF
--- a/android/src/com/frostwire/android/gui/fragments/SearchFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/SearchFragment.java
@@ -44,6 +44,7 @@ import com.frostwire.android.R;
 import com.frostwire.android.core.ConfigurationManager;
 import com.frostwire.android.core.Constants;
 import com.frostwire.android.gui.LocalSearchEngine;
+import com.frostwire.android.gui.NetworkManager;
 import com.frostwire.android.gui.adapters.OnFeedbackClickAdapter;
 import com.frostwire.android.gui.adapters.PromotionDownloader;
 import com.frostwire.android.gui.adapters.SearchResultListAdapter;
@@ -164,7 +165,6 @@ public final class SearchFragment extends AbstractFragment implements
 
         return header;
     }
-
 
     @Override
     public void onResume() {
@@ -901,7 +901,11 @@ public final class SearchFragment extends AbstractFragment implements
 
         // self determine if it should be hidden or not
         public void updateVisibility() {
-            setVisible(currentQuery != null);
+            if ( currentQuery == null || NetworkManager.instance().isInternetDown() || adapter.getCount() <= 0) {
+                filterButton.setVisible(false);
+            } else {
+                filterButton.setVisible(true);
+            }
         }
 
         @Override


### PR DESCRIPTION
… in no results

Currently the filter button on search page and the filter drawer were active even when there was no Internet connection at all or there was absolutely no search results present after search even with connection present. So the drawer opened with no filters as there was no search results. 

Wanted to hide the filterButton from the toolbar when no search results are displayed. 
