### PR TITLE
[android] Open Menu Action to open image with external Image Viewer

### DIFF
--- a/android/src/com/frostwire/android/gui/fragments/ImageViewerFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/ImageViewerFragment.java
@@ -232,15 +232,11 @@ public final class ImageViewerFragment extends AbstractFragment {
                 case R.id.fragment_my_files_action_mode_menu_seed:
                     new SeedAction(context, fd, null).onClick();
                     break;
-                case R.id.fragment_my_files_action_mode_menu_open:
-                    if (inFullScreenMode) {
-                        new OpenMenuAction(context, fd).onClick();
-                    } else {
+                case R.id.fragment_my_files_action_mode_menu_open:ast
                         Intent intent = new Intent();
                         intent.setAction(Intent.ACTION_VIEW);
                         intent.setDataAndType(Uri.fromFile(new File(fd.filePath)), "image/*");
                         startActivity(intent);
-                    }
                     break;
                 case R.id.fragment_my_files_action_mode_menu_file_information:
                     new FileInformationAction(context, fd).onClick();

--- a/android/src/com/frostwire/android/gui/fragments/ImageViewerFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/ImageViewerFragment.java
@@ -20,6 +20,7 @@ package com.frostwire.android.gui.fragments;
 
 import android.app.Activity;
 import android.content.ContentUris;
+import android.content.Intent;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.Bundle;
@@ -232,7 +233,14 @@ public final class ImageViewerFragment extends AbstractFragment {
                     new SeedAction(context, fd, null).onClick();
                     break;
                 case R.id.fragment_my_files_action_mode_menu_open:
-                    new OpenMenuAction(context, fd).onClick();
+                    if (inFullScreenMode) {
+                        new OpenMenuAction(context, fd).onClick();
+                    } else {
+                        Intent intent = new Intent();
+                        intent.setAction(Intent.ACTION_VIEW);
+                        intent.setDataAndType(Uri.fromFile(new File(fd.filePath)), "image/*");
+                        startActivity(intent);
+                    }
                     break;
                 case R.id.fragment_my_files_action_mode_menu_file_information:
                     new FileInformationAction(context, fd).onClick();

--- a/android/src/com/frostwire/android/gui/fragments/ImageViewerFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/ImageViewerFragment.java
@@ -232,7 +232,7 @@ public final class ImageViewerFragment extends AbstractFragment {
                 case R.id.fragment_my_files_action_mode_menu_seed:
                     new SeedAction(context, fd, null).onClick();
                     break;
-                case R.id.fragment_my_files_action_mode_menu_open:ast
+                case R.id.fragment_my_files_action_mode_menu_open:
                         Intent intent = new Intent();
                         intent.setAction(Intent.ACTION_VIEW);
                         intent.setDataAndType(Uri.fromFile(new File(fd.filePath)), "image/*");


### PR DESCRIPTION
Issue #585: @gubatron yes it meant to open an image in the external image viewer in case a user want to easily go and edit an image or further apply some fun filters we of course wont have as a downloader app. 

But it only should leave the app when in fullScreenMode. Hence the added code. 
As of now when we select one image - and are in selection more - we can use the Open Menu Action to view that selected image in full screen mode within FrostWire. 