### PR TITLE
[WIP] Setting up correclty strings to empty fragments

### DIFF
--- a/android/apollo/res/values/strings.xml
+++ b/android/apollo/res/values/strings.xml
@@ -164,6 +164,6 @@
     <string name="empty_last_added">Songs you have added over the last month will be shown here.</string>
     <string name="empty_search">No search results found</string>
     <string name="empty_favorite">Songs you mark as favorites will be shown here.</string>
-    <string name="empty_recent">Albums you have listened to will show up here. Try playing some music.</string>
+    <string name="empty_recent">Songs you have listened to will show up here. Try playing some music.</string>
     <string name="frostwire_player">FrostWire Player</string>
 </resources>

--- a/android/apollo/src/com/andrew/apollo/loaders/LastAddedLoader.java
+++ b/android/apollo/src/com/andrew/apollo/loaders/LastAddedLoader.java
@@ -37,8 +37,7 @@ public class LastAddedLoader extends SongLoader {
 
     @Override
     public Cursor makeCursor(Context context) {
-        Cursor c = makeLastAddedCursor(getContext());
-        return c;
+        return makeLastAddedCursor(getContext());
     }
 
     /**

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/LastAddedFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/LastAddedFragment.java
@@ -81,4 +81,10 @@ public final class LastAddedFragment extends ApolloFragment<SongAdapter, Song> {
             mAdapter.notifyDataSetChanged();
         }
     }
+
+    @Override
+    public void onLoadFinished(final Loader<List<Song>> loader, final List<Song> data) {
+        mDefaultFragmentEmptyString = R.string.empty_last_added;
+        super.onLoadFinished(loader, data);
+    }
 }

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/RecentFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/RecentFragment.java
@@ -91,7 +91,7 @@ public final class RecentFragment extends ApolloFragment<SongAdapter, Song> {
 
     @Override
     public void onLoadFinished(final Loader<List<Song>> loader, final List<Song> data) {
-        mDefaultFragmentEmptyString = R.string.empty_last_added;
+        mDefaultFragmentEmptyString = R.string.empty_recent;
         super.onLoadFinished(loader, data);
     }
 }

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/RecentFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/RecentFragment.java
@@ -88,4 +88,9 @@ public final class RecentFragment extends ApolloFragment<SongAdapter, Song> {
             threadPool.execute(() -> restartLoader(true));
         }
     }
+
+    @Override
+    public int getEmptyStringId(){
+        return R.string.empty_recent;
+    }
 }

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/RecentFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/RecentFragment.java
@@ -90,7 +90,8 @@ public final class RecentFragment extends ApolloFragment<SongAdapter, Song> {
     }
 
     @Override
-    public int getEmptyStringId(){
-        return R.string.empty_recent;
+    public void onLoadFinished(final Loader<List<Song>> loader, final List<Song> data) {
+        mDefaultFragmentEmptyString = R.string.empty_last_added;
+        super.onLoadFinished(loader, data);
     }
 }

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/profile/ApolloFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/profile/ApolloFragment.java
@@ -450,7 +450,7 @@ public abstract class ApolloFragment<T extends ApolloFragmentAdapter<I>, I>
             // Set the empty text
             final TextView empty = mRootView.findViewById(R.id.empty);
             if (empty != null) {
-                empty.setText(getString(R.string.empty_music));
+                empty.setText(getString(getEmptyStringId()));
                 if (isSimpleLayout()) {
                     mListView.setEmptyView(empty);
                 } else {
@@ -487,6 +487,10 @@ public abstract class ApolloFragment<T extends ApolloFragmentAdapter<I>, I>
 
             mAdapter.notifyDataSetChanged();
         }
+    }
+
+    public int getEmptyStringId(){
+        return R.string.empty_music;
     }
 
     @Override

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/profile/ApolloFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/profile/ApolloFragment.java
@@ -127,6 +127,8 @@ public abstract class ApolloFragment<T extends ApolloFragmentAdapter<I>, I>
 
     protected ViewGroup mRootView;
 
+    protected Integer mDefaultFragmentEmptyString = null;
+
     private volatile long lastRestartLoader;
 
     protected abstract T createAdapter();
@@ -450,7 +452,7 @@ public abstract class ApolloFragment<T extends ApolloFragmentAdapter<I>, I>
             // Set the empty text
             final TextView empty = mRootView.findViewById(R.id.empty);
             if (empty != null) {
-                empty.setText(getString(getEmptyStringId()));
+                empty.setText(getString((mDefaultFragmentEmptyString != null) ? mDefaultFragmentEmptyString : R.string.empty_music));
                 if (isSimpleLayout()) {
                     mListView.setEmptyView(empty);
                 } else {
@@ -487,10 +489,6 @@ public abstract class ApolloFragment<T extends ApolloFragmentAdapter<I>, I>
 
             mAdapter.notifyDataSetChanged();
         }
-    }
-
-    public int getEmptyStringId(){
-        return R.string.empty_music;
     }
 
     @Override

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/profile/ApolloFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/profile/ApolloFragment.java
@@ -452,7 +452,8 @@ public abstract class ApolloFragment<T extends ApolloFragmentAdapter<I>, I>
             // Set the empty text
             final TextView empty = mRootView.findViewById(R.id.empty);
             if (empty != null) {
-                empty.setText(getString((mDefaultFragmentEmptyString != null) ? mDefaultFragmentEmptyString : R.string.empty_music));
+                empty.setText((mDefaultFragmentEmptyString != null) ?
+                        mDefaultFragmentEmptyString : R.string.empty_music);
                 if (isSimpleLayout()) {
                     mListView.setEmptyView(empty);
                 } else {

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/profile/LastAddedFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/profile/LastAddedFragment.java
@@ -67,8 +67,16 @@ public final class LastAddedFragment extends ApolloFragment<ProfileSongAdapter, 
     }
 
     @Override
-    public int getEmptyStringId(){
-        return R.string.empty_last_added;
+    public void onLoadFinished(final Loader<List<Song>> loader, final List<Song> data) {
+        super.onLoadFinished(loader, data);
+        if (data.isEmpty()) {
+            // Set the empty text
+            if (mRootView != null) {
+                final TextView empty = mRootView.findViewById(R.id.empty);
+                empty.setText(getString(R.string.empty_last_added));
+                mListView.setEmptyView(empty);
+            }
+        }
     }
 
     @Override

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/profile/LastAddedFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/profile/LastAddedFragment.java
@@ -66,18 +66,9 @@ public final class LastAddedFragment extends ApolloFragment<ProfileSongAdapter, 
         onSongItemClick(position);
     }
 
-
     @Override
-    public void onLoadFinished(final Loader<List<Song>> loader, final List<Song> data) {
-        super.onLoadFinished(loader, data);
-        if (data.isEmpty()) {
-            // Set the empty text
-            if (mRootView != null) {
-                final TextView empty = mRootView.findViewById(R.id.empty);
-                empty.setText(getString(R.string.empty_last_added));
-                mListView.setEmptyView(empty);
-            }
-        }
+    public int getEmptyStringId(){
+        return R.string.empty_last_added;
     }
 
     @Override


### PR DESCRIPTION
This pull request is intended to add default strings when fragments are empty correctly.

The idea is basically add to ApolloFragment a method called `getEmptyStringId()` that will return the default string id `R.string.empty_music`. 

Then that method will be overriden by subclasses of ApolloFragment such as `RecentFragment` or `LastAddedFragment` for example. 



