### PR TITLE
[android] Changing itemsOffset parameter in SongFragment 

### DIFF
--- a/android/apollo/src/com/andrew/apollo/ui/fragments/SongFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/SongFragment.java
@@ -47,7 +47,7 @@ public final class SongFragment extends ApolloFragment<SongAdapter, Song> {
 
     @Override
     protected SongAdapter createAdapter() {
-        return new SongAdapter(getActivity(), R.layout.list_item_simple_image, 1);
+        return new SongAdapter(getActivity(), R.layout.list_item_simple_image, 0);
     }
 
     @Override


### PR DESCRIPTION
Changing itemsOffset parameter in SongFragment to avoid blank row creating at the end of the list.


![screenshot_20180615-203141](https://user-images.githubusercontent.com/368680/41495032-77c5dffc-70db-11e8-9b53-05a5a4f298c3.png)
