### PR TITLE
[android] Shutdown logic revision

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -20,7 +20,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.frostwire.android"
     android:installLocation="auto"
-    android:versionCode="558"
+    android:versionCode="559"
     android:versionName="2.0.8">
     <!-- IMPORTANT!! Ignore these, just use as a reference, now it's handled with gradle -->
     <!-- Plus  android:versionCode="9070xyz" (always commit like this, plus!)-->

--- a/android/src/com/frostwire/android/gui/activities/MainActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/MainActivity.java
@@ -77,7 +77,6 @@ import com.frostwire.android.gui.views.MiniPlayerView;
 import com.frostwire.android.gui.views.TimerService;
 import com.frostwire.android.gui.views.TimerSubscription;
 import com.frostwire.android.offers.Offers;
-import com.frostwire.android.util.SystemUtils;
 import com.frostwire.platform.Platforms;
 import com.frostwire.util.Logger;
 import com.frostwire.util.Ref;
@@ -199,12 +198,10 @@ public class MainActivity extends AbstractActivity implements
         }
         shuttingdown = true;
         LocalSearchEngine.instance().cancelSearch();
-        Offers.stopAdNetworks(this);
         //UXStats.instance().flush(true); // sends data and ends 3rd party APIs sessions.
         finish();
         Engine.instance().shutdown();
         MusicUtils.requestMusicPlaybackServiceShutdown(this);
-        SystemUtils.requestKillProcess(this);
     }
 
     @Override
@@ -483,7 +480,7 @@ public class MainActivity extends AbstractActivity implements
             mToken = null;
         }
         // necessary unregisters broadcast its internal receivers, avoids leaks.
-        Offers.destroyMopubInterstitials(this);
+        Offers.destroyMopubInterstitials();
     }
 
     private void saveLastFragment(Bundle outState) {
@@ -504,6 +501,9 @@ public class MainActivity extends AbstractActivity implements
                 firstTime = false;
                 Engine.instance().startServices(); // it's necessary for the first time after wizard
             }
+        }
+        if (Engine.instance().wasShutdown()) {
+            Engine.instance().startServices();
         }
         SoftwareUpdater.getInstance().checkForUpdate(this);
     }

--- a/android/src/com/frostwire/android/gui/activities/MainActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/MainActivity.java
@@ -858,10 +858,7 @@ public class MainActivity extends AbstractActivity implements
         try {
             File data = Platforms.data();
             File parent = data.getParentFile();
-            if (!AndroidPlatform.saf(parent)) {
-                return false;
-            }
-            return (!Platforms.fileSystem().canWrite(parent) && !SDPermissionDialog.visible);
+            return AndroidPlatform.saf(parent) && (!Platforms.fileSystem().canWrite(parent) && !SDPermissionDialog.visible);
         } catch (Throwable e) {
             // we can't do anything about this
             LOG.error("Unable to detect if we have SD permissions", e);

--- a/android/src/com/frostwire/android/gui/services/Engine.java
+++ b/android/src/com/frostwire/android/gui/services/Engine.java
@@ -63,8 +63,13 @@ public final class Engine implements IEngineService {
     // the creation of the service is not (and can't be) synchronized
     // with the main activity resume.
     private boolean pendingStartServices = false;
+    private boolean wasShutdown;
 
     private Engine() {
+    }
+
+    public boolean wasShutdown() {
+        return wasShutdown;
     }
 
     private static class Loader {
@@ -116,8 +121,9 @@ public final class Engine implements IEngineService {
     }
 
     public void startServices() {
-        if (service != null) {
-            service.startServices();
+        if (service != null || wasShutdown) {
+            service.startServices(wasShutdown);
+            wasShutdown = false;
         } else {
             // save pending startServices call
             pendingStartServices = true;
@@ -163,6 +169,7 @@ public final class Engine implements IEngineService {
                 }
             }
             service.shutdown();
+            wasShutdown = true;
         }
     }
 

--- a/android/src/com/frostwire/android/gui/services/EngineService.java
+++ b/android/src/com/frostwire/android/gui/services/EngineService.java
@@ -213,7 +213,6 @@ public class EngineService extends Service implements IEngineService {
             btEngine.start();
             TransferManager.instance().loadTorrentsTask();
             btEngine.resume();
-
         }
         engineService.state = STATE_STARTED;
         LOG.info("resumeBTEngineTask(): Engine started", true);

--- a/android/src/com/frostwire/android/gui/transfers/TransferManager.java
+++ b/android/src/com/frostwire/android/gui/transfers/TransferManager.java
@@ -568,7 +568,7 @@ public final class TransferManager {
 
     }
 
-    private void loadTorrentsTask() {
+    public void loadTorrentsTask() {
         bittorrentDownloadsList.clear();
         bittorrentDownloadsMap.clear();
         final BTEngine btEngine = BTEngine.getInstance();

--- a/android/src/com/frostwire/android/gui/util/DangerousPermissionsChecker.java
+++ b/android/src/com/frostwire/android/gui/util/DangerousPermissionsChecker.java
@@ -34,8 +34,6 @@ import com.frostwire.android.R;
 import com.frostwire.android.core.ConfigurationManager;
 import com.frostwire.android.core.Constants;
 import com.frostwire.android.gui.services.Engine;
-import com.frostwire.android.offers.Offers;
-import com.frostwire.android.util.SystemUtils;
 import com.frostwire.util.Logger;
 import com.frostwire.util.Ref;
 
@@ -270,11 +268,8 @@ public final class DangerousPermissionsChecker implements ActivityCompat.OnReque
             return;
         }
         final Activity activity = activityRef.get();
-
-        Offers.stopAdNetworks(activity);
         activity.finish();
         Engine.instance().shutdown();
         MusicUtils.requestMusicPlaybackServiceShutdown(activity);
-        SystemUtils.requestKillProcess(activity);
     }
 }

--- a/android/src/com/frostwire/android/offers/MoPubAdNetwork.java
+++ b/android/src/com/frostwire/android/offers/MoPubAdNetwork.java
@@ -43,7 +43,6 @@ import com.mopub.mobileads.MoPubInterstitial;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;

--- a/android/src/com/frostwire/android/offers/Offers.java
+++ b/android/src/com/frostwire/android/offers/Offers.java
@@ -78,13 +78,9 @@ public final class Offers {
         }
         PrebidManager.getInstance(activity);
         LOG.info("Offers.initAdNetworks() success");
-        return;
     }
 
     public static void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-//        if (AD_NETWORKS == null) {
-//            return;
-//        }
     }
 
     private static Map<String, AdNetwork> getAllAdNetworks() {
@@ -386,10 +382,6 @@ public final class Offers {
 
             if (activity != null) {
                 if (shutdownAfter) {
-                    if (adNetwork != null) {
-                        adNetwork.stop(activity);
-                    }
-
                     if (activity instanceof MainActivity) {
                         LOG.info("dismissAndOrShutdownIfNecessary: MainActivity.shutdown()");
                         ((MainActivity) activity).shutdown();
@@ -401,10 +393,6 @@ public final class Offers {
                 }
 
                 if (finishAfterDismiss) {
-//                    if (adNetwork != null) {
-//                        adNetwork.stop(activity);
-//                    }
-
                     if (activity instanceof MainActivity) {
                         activity.finish();
                     } else {

--- a/android/src/com/frostwire/android/offers/Offers.java
+++ b/android/src/com/frostwire/android/offers/Offers.java
@@ -97,8 +97,8 @@ public final class Offers {
         return AD_NETWORKS;
     }
 
-    public static void destroyMopubInterstitials(Context context) {
-        MOPUB.stop(context);
+    public static void destroyMopubInterstitials() {
+        MOPUB.destroyInterstitials();
     }
 
     public static void stopAdNetworks(Context context) {


### PR DESCRIPTION
@aldenml @muckachina please take a look at this and test this branch.
The purpose of this branch is to perform a passive shutdown of FrostWire, in the past we tried to force kill all services and the process which is against Android's nature, which will try to revive the process anyway.

It's working as expected, at least what I've tested:

1. That ad networks aren't shutdown and they continue to work, both banners and interstitials. Had to perform a reflection hack on a MoPubInterstitial class to reload interstitials that were destroyed upon exit.

2. HTTP and Image loading works after restart

3. Bittorrent transfers work after restart

4. Previous BitTorrent transfers are restored to their previous stage, however, there's a hiccup on which you will see previous transfers in "Error" state for a second, perhaps you know how to fix this, I was "tirando flechas" on how to restore the bittorrent session. See [this](https://github.com/frostwire/frostwire/commit/bcd10152520032ec2944a9e943dff61520f1f5a4#diff-7f3416d798dcaa50e7aed143a06e0fc4R212) which is the only code that I got it to work with, I bet you'll see the flaw. The issue is that when the torrent engine is stopped the `session` object is destroyed, so I try to recreate a new session from scratch. (That code I linked all occurs on a background thread when you stop the debugger there).

**Still untested: Ad-Removal behavior.**

I think this will also fix issues with Ad-Removal and ads coming back, I've yet to test if ads are still hidden after a restart, they should probably be. But now, we don't kill the PlayStore services on Exit, perhaps that was also causing issues.

Playing with fire, but lots of benefits, like not ever having again the crash that occurred when you tried opening frostwire right after a shutdown and it was still shutting down.