### PR TITLE
[android] Shutdown logic fix

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -20,7 +20,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.frostwire.android"
     android:installLocation="auto"
-    android:versionCode="558"
+    android:versionCode="559"
     android:versionName="2.0.8">
     <!-- IMPORTANT!! Ignore these, just use as a reference, now it's handled with gradle -->
     <!-- Plus  android:versionCode="9070xyz" (always commit like this, plus!)-->

--- a/android/src/com/frostwire/android/gui/activities/MainActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/MainActivity.java
@@ -77,7 +77,6 @@ import com.frostwire.android.gui.views.MiniPlayerView;
 import com.frostwire.android.gui.views.TimerService;
 import com.frostwire.android.gui.views.TimerSubscription;
 import com.frostwire.android.offers.Offers;
-import com.frostwire.android.util.SystemUtils;
 import com.frostwire.platform.Platforms;
 import com.frostwire.util.Logger;
 import com.frostwire.util.Ref;
@@ -199,12 +198,10 @@ public class MainActivity extends AbstractActivity implements
         }
         shuttingdown = true;
         LocalSearchEngine.instance().cancelSearch();
-        Offers.stopAdNetworks(this);
         //UXStats.instance().flush(true); // sends data and ends 3rd party APIs sessions.
         finish();
         Engine.instance().shutdown();
         MusicUtils.requestMusicPlaybackServiceShutdown(this);
-        SystemUtils.requestKillProcess(this);
     }
 
     @Override
@@ -483,7 +480,7 @@ public class MainActivity extends AbstractActivity implements
             mToken = null;
         }
         // necessary unregisters broadcast its internal receivers, avoids leaks.
-        Offers.destroyMopubInterstitials(this);
+        Offers.destroyMopubInterstitials();
     }
 
     private void saveLastFragment(Bundle outState) {
@@ -504,6 +501,9 @@ public class MainActivity extends AbstractActivity implements
                 firstTime = false;
                 Engine.instance().startServices(); // it's necessary for the first time after wizard
             }
+        }
+        if (Engine.instance().wasShutdown()) {
+            Engine.instance().startServices();
         }
         SoftwareUpdater.getInstance().checkForUpdate(this);
     }

--- a/android/src/com/frostwire/android/gui/activities/MainActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/MainActivity.java
@@ -858,10 +858,7 @@ public class MainActivity extends AbstractActivity implements
         try {
             File data = Platforms.data();
             File parent = data.getParentFile();
-            if (!AndroidPlatform.saf(parent)) {
-                return false;
-            }
-            return (!Platforms.fileSystem().canWrite(parent) && !SDPermissionDialog.visible);
+            return AndroidPlatform.saf(parent) && (!Platforms.fileSystem().canWrite(parent) && !SDPermissionDialog.visible);
         } catch (Throwable e) {
             // we can't do anything about this
             LOG.error("Unable to detect if we have SD permissions", e);

--- a/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
@@ -286,6 +286,10 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
 
     @Override
     public void onTime() {
+        if (!isVisible()) {
+            return;
+        }
+
         if (adapter != null) {
             async(this,
                     TransfersFragment::sortSelectedStatusTransfersInBackground,

--- a/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
@@ -239,6 +239,7 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
     public void onDestroyView() {
         super.onDestroyView();
         subscription.unsubscribe();
+        adapter = null;
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/services/Engine.java
+++ b/android/src/com/frostwire/android/gui/services/Engine.java
@@ -63,8 +63,13 @@ public final class Engine implements IEngineService {
     // the creation of the service is not (and can't be) synchronized
     // with the main activity resume.
     private boolean pendingStartServices = false;
+    private boolean wasShutdown;
 
     private Engine() {
+    }
+
+    public boolean wasShutdown() {
+        return wasShutdown;
     }
 
     private static class Loader {
@@ -116,8 +121,9 @@ public final class Engine implements IEngineService {
     }
 
     public void startServices() {
-        if (service != null) {
-            service.startServices();
+        if (service != null || wasShutdown) {
+            service.startServices(wasShutdown);
+            wasShutdown = false;
         } else {
             // save pending startServices call
             pendingStartServices = true;
@@ -163,6 +169,7 @@ public final class Engine implements IEngineService {
                 }
             }
             service.shutdown();
+            wasShutdown = true;
         }
     }
 

--- a/android/src/com/frostwire/android/gui/services/Engine.java
+++ b/android/src/com/frostwire/android/gui/services/Engine.java
@@ -28,7 +28,6 @@ import android.net.ConnectivityManager;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
-import android.os.SystemClock;
 import android.os.Vibrator;
 import android.telephony.TelephonyManager;
 

--- a/android/src/com/frostwire/android/gui/services/Engine.java
+++ b/android/src/com/frostwire/android/gui/services/Engine.java
@@ -64,7 +64,6 @@ public final class Engine implements IEngineService {
     // with the main activity resume.
     private boolean pendingStartServices = false;
     private boolean wasShutdown;
-    private long lastRestarted;
 
     private Engine() {
     }
@@ -123,17 +122,14 @@ public final class Engine implements IEngineService {
 
     public void startServices() {
         if (service != null || wasShutdown) {
-            service.startServices(wasShutdown);
+            if (service != null) {
+                service.startServices(wasShutdown);
+            }
             wasShutdown = false;
-            lastRestarted = System.currentTimeMillis();
         } else {
             // save pending startServices call
             pendingStartServices = true;
         }
-    }
-
-    public long lastRestarted() {
-        return lastRestarted;
     }
 
     public void stopServices(boolean disconnected) {

--- a/android/src/com/frostwire/android/gui/services/Engine.java
+++ b/android/src/com/frostwire/android/gui/services/Engine.java
@@ -28,6 +28,7 @@ import android.net.ConnectivityManager;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.os.Vibrator;
 import android.telephony.TelephonyManager;
 
@@ -64,6 +65,7 @@ public final class Engine implements IEngineService {
     // with the main activity resume.
     private boolean pendingStartServices = false;
     private boolean wasShutdown;
+    private long lastRestarted;
 
     private Engine() {
     }
@@ -124,10 +126,15 @@ public final class Engine implements IEngineService {
         if (service != null || wasShutdown) {
             service.startServices(wasShutdown);
             wasShutdown = false;
+            lastRestarted = System.currentTimeMillis();
         } else {
             // save pending startServices call
             pendingStartServices = true;
         }
+    }
+
+    public long lastRestarted() {
+        return lastRestarted;
     }
 
     public void stopServices(boolean disconnected) {

--- a/android/src/com/frostwire/android/gui/services/EngineService.java
+++ b/android/src/com/frostwire/android/gui/services/EngineService.java
@@ -213,7 +213,6 @@ public class EngineService extends Service implements IEngineService {
             btEngine.start();
             TransferManager.instance().loadTorrentsTask();
             btEngine.resume();
-
         }
         engineService.state = STATE_STARTED;
         LOG.info("resumeBTEngineTask(): Engine started", true);

--- a/android/src/com/frostwire/android/gui/services/EngineService.java
+++ b/android/src/com/frostwire/android/gui/services/EngineService.java
@@ -211,7 +211,7 @@ public class EngineService extends Service implements IEngineService {
             btEngine.resume();
         } else {
             btEngine.start();
-            TransferManager.instance().loadTorrentsTask();
+            TransferManager.instance().reset();
             btEngine.resume();
         }
         engineService.state = STATE_STARTED;
@@ -226,6 +226,7 @@ public class EngineService extends Service implements IEngineService {
         state = STATE_STOPPING;
 
         LOG.info("Pausing BTEngine...");
+        TransferManager.instance().onShutdown();
         BTEngine.getInstance().pause();
         LOG.info("Pausing BTEngine paused");
 

--- a/android/src/com/frostwire/android/gui/transfers/TransferManager.java
+++ b/android/src/com/frostwire/android/gui/transfers/TransferManager.java
@@ -568,7 +568,7 @@ public final class TransferManager {
 
     }
 
-    private void loadTorrentsTask() {
+    public void loadTorrentsTask() {
         bittorrentDownloadsList.clear();
         bittorrentDownloadsMap.clear();
         final BTEngine btEngine = BTEngine.getInstance();

--- a/android/src/com/frostwire/android/gui/transfers/UIBittorrentDownload.java
+++ b/android/src/com/frostwire/android/gui/transfers/UIBittorrentDownload.java
@@ -323,7 +323,7 @@ public final class UIBittorrentDownload implements BittorrentDownload {
             engine.notifyDownloadFinished(getDisplayName(), saveLocation, dl.getInfoHash());
             long lastRestarted = engine.lastRestarted();
             // if restarted, wait at least 1 minute before performing a file system scan
-            if (lastRestarted == -1 || ((System.currentTimeMillis()-lastRestarted) > 60000)) {
+            if (lastRestarted == -1 || ((System.currentTimeMillis() - lastRestarted) > 60000)) {
                 Platforms.fileSystem().scan(saveLocation);
             } else {
                 LOG.info("StatusListener.finished() - skipping file system scan, too early");

--- a/android/src/com/frostwire/android/gui/transfers/UIBittorrentDownload.java
+++ b/android/src/com/frostwire/android/gui/transfers/UIBittorrentDownload.java
@@ -316,18 +316,16 @@ public final class UIBittorrentDownload implements BittorrentDownload {
 
         @Override
         public void finished(BTDownload dl) {
+            // this method will be called for all finished transfers even right after the app has been opened the first
+            // time, right after it's done resuming transfers
+
             pauseSeedingIfNecessary(dl);
             TransferManager.instance().incrementDownloadsToReview();
-            File saveLocation = getSavePath().getAbsoluteFile();
+            File savePath = getSavePath().getAbsoluteFile(); // e.g. "Torrent Data"
             Engine engine = Engine.instance();
-            engine.notifyDownloadFinished(getDisplayName(), saveLocation, dl.getInfoHash());
-            long lastRestarted = engine.lastRestarted();
-            // if restarted, wait at least 1 minute before performing a file system scan
-            if (lastRestarted == -1 || ((System.currentTimeMillis() - lastRestarted) > 60000)) {
-                Platforms.fileSystem().scan(saveLocation);
-            } else {
-                LOG.info("StatusListener.finished() - skipping file system scan, too early");
-            }
+            engine.notifyDownloadFinished(getDisplayName(), savePath, dl.getInfoHash());
+            File torrentSaveFolder = dl.getContentSavePath();
+            Platforms.fileSystem().scan(torrentSaveFolder);
         }
 
         private void pauseSeedingIfNecessary(BTDownload dl) {

--- a/android/src/com/frostwire/android/gui/util/DangerousPermissionsChecker.java
+++ b/android/src/com/frostwire/android/gui/util/DangerousPermissionsChecker.java
@@ -34,8 +34,6 @@ import com.frostwire.android.R;
 import com.frostwire.android.core.ConfigurationManager;
 import com.frostwire.android.core.Constants;
 import com.frostwire.android.gui.services.Engine;
-import com.frostwire.android.offers.Offers;
-import com.frostwire.android.util.SystemUtils;
 import com.frostwire.util.Logger;
 import com.frostwire.util.Ref;
 
@@ -270,11 +268,8 @@ public final class DangerousPermissionsChecker implements ActivityCompat.OnReque
             return;
         }
         final Activity activity = activityRef.get();
-
-        Offers.stopAdNetworks(activity);
         activity.finish();
         Engine.instance().shutdown();
         MusicUtils.requestMusicPlaybackServiceShutdown(activity);
-        SystemUtils.requestKillProcess(activity);
     }
 }

--- a/android/src/com/frostwire/android/offers/MoPubAdNetwork.java
+++ b/android/src/com/frostwire/android/offers/MoPubAdNetwork.java
@@ -43,7 +43,6 @@ import com.mopub.mobileads.MoPubInterstitial;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;

--- a/android/src/com/frostwire/android/offers/Offers.java
+++ b/android/src/com/frostwire/android/offers/Offers.java
@@ -78,13 +78,9 @@ public final class Offers {
         }
         PrebidManager.getInstance(activity);
         LOG.info("Offers.initAdNetworks() success");
-        return;
     }
 
     public static void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-//        if (AD_NETWORKS == null) {
-//            return;
-//        }
     }
 
     private static Map<String, AdNetwork> getAllAdNetworks() {
@@ -386,10 +382,6 @@ public final class Offers {
 
             if (activity != null) {
                 if (shutdownAfter) {
-                    if (adNetwork != null) {
-                        adNetwork.stop(activity);
-                    }
-
                     if (activity instanceof MainActivity) {
                         LOG.info("dismissAndOrShutdownIfNecessary: MainActivity.shutdown()");
                         ((MainActivity) activity).shutdown();
@@ -401,10 +393,6 @@ public final class Offers {
                 }
 
                 if (finishAfterDismiss) {
-//                    if (adNetwork != null) {
-//                        adNetwork.stop(activity);
-//                    }
-
                     if (activity instanceof MainActivity) {
                         activity.finish();
                     } else {

--- a/android/src/com/frostwire/android/offers/Offers.java
+++ b/android/src/com/frostwire/android/offers/Offers.java
@@ -97,8 +97,8 @@ public final class Offers {
         return AD_NETWORKS;
     }
 
-    public static void destroyMopubInterstitials(Context context) {
-        MOPUB.stop(context);
+    public static void destroyMopubInterstitials() {
+        MOPUB.destroyInterstitials();
     }
 
     public static void stopAdNetworks(Context context) {

--- a/common/src/main/java/com/frostwire/bittorrent/BTEngine.java
+++ b/common/src/main/java/com/frostwire/bittorrent/BTEngine.java
@@ -718,6 +718,10 @@ public final class BTEngine extends SessionManager {
             }
         } else { // new download
             download(ti, saveDir, resumeFile, priorities, peers);
+            th = find(ti.infoHash());
+            if (th != null) {
+                fireDownloadUpdate(th);
+            }
         }
     }
 


### PR DESCRIPTION
@aldenml @muckachina please take a look at this and test this branch.
The purpose of this branch is to perform a passive shutdown of FrostWire, in the past we tried to force kill all services and the process which is against Android's nature, which will try to revive the process anyway.

It's working as expected, at least what I've tested:

    That ad networks aren't shutdown and they continue to work, both banners and interstitials. Had to perform a reflection hack on a MoPubInterstitial class to reload interstitials that were destroyed upon exit.

    HTTP and Image loading works after restart

    Bittorrent transfers work after restart

    Previous BitTorrent transfers are restored to their previous stage, however, there's a hiccup on which you will see previous transfers in "Error" state for a second, perhaps you know how to fix this, I was "tirando flechas" on how to restore the bittorrent session. See this which is the only code that I got it to work with, I bet you'll see the flaw. The issue is that when the torrent engine is stopped the session object is destroyed, so I try to recreate a new session from scratch. (That code I linked all occurs on a background thread when you stop the debugger there).

Still untested: Ad-Removal behavior.

I think this will also fix issues with Ad-Removal and ads coming back, I've yet to test if ads are still hidden after a restart, they should probably be. But now, we don't kill the PlayStore services on Exit, perhaps that was also causing issues.

Playing with fire, but lots of benefits, like not ever having again the crash that occurred when you tried opening frostwire right after a shutdown and it was still shutting down.