### PR TITLE
[android] adding initStorageRelatedRichNotifications in onResume

### DIFF
--- a/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/TransfersFragment.java
@@ -232,6 +232,7 @@ public class TransfersFragment extends AbstractFragment implements TimerObserver
     @Override
     public void onResume() {
         super.onResume();
+        initStorageRelatedRichNotifications(null);
         onTime();
     }
 


### PR DESCRIPTION
@gubatron it looks like it just was not called from onResume, only on initComponents. Adding to onResume did the trick for me. 