### PR TITLE
[common] Added 1337x torrent search support

### DIFF
--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -83,6 +83,7 @@
     <string name="use_torrentz2">Benutze Torrentz2</string>
     <string name="use_eztv">Benutze Eztv</string>
     <string name="use_yify">Benutze Yify</string>
+    <string name="use_one337x">Benutze 1337x</string>
     <string name="use_frostclick">Benutze FrostClick</string>
     <string name="use_archiveorg">Benutze Archive.org</string>
     <string name="use_soundcloud">Benutze Soundcloud.com</string>

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -179,6 +179,7 @@
     <string name="torrent_url_added">URL de Torrent añadida a las transferencias.</string>
     <string name="please_enter_valid_url">Por favor, ingresa una URL válida</string>
     <string name="use_yify">Usar Yify</string>
+    <string name="use_one337x">Usar 1337x</string>
     <string name="torrent_transfer_consuming_mobile_data">Advertencia: Esta transferencia de torrent está usando tu data 3G/4G (Revisa tus preferencias de red si deseas usar BitTorrent solo con Wi-Fi)</string>
     <string name="transfers_context_resume_all_torrent_transfers">Reanudar todas las transferencias Torrent</string>
     <string name="cant_open_file_does_not_exist">No puedo abrir %1$s, el archivo no existe.</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -183,6 +183,7 @@
     <string name="please_enter_valid_url">S\'il vous plaît entrer une URL valide</string>
     <string name="available">disponible</string>
     <string name="use_yify">Utilisez Yify</string>
+    <string name="use_one337x">Utilisez 1337x</string>
     <string name="torrent_transfer_consuming_mobile_data">Attention: Ce transfert de torrent utilise vos données 3G/4G. (Vérifiez vos préférences de réseau si vous souhaitez utiliser BitTorrent uniquement sur WiFi)</string>
     <string name="transfers_context_resume_all_torrent_transfers">Reprendre tous les transferts torrent</string>
     <string name="storage_setting_confirm_dialog_title">CARTE SD</string>

--- a/android/res/values-hi/strings.xml
+++ b/android/res/values-hi/strings.xml
@@ -227,6 +227,7 @@
     <string name="available">उपलब्ध</string>
     <string name="check_internet_connection">इंटरनेट कनेक्शन की जांच</string>
     <string name="use_yify">उपयोग Yify</string>
+    <string name="use_one337x">उपयोग 1337x</string>
     <string name="transfers_context_menu_copy_infohash_copied">जानकारी हैश क्लिपबोर्ड करने के लिए नकल</string>
     <string name="haptic_feedback">हप्टिक राय</string>
     <string name="yes_no_cancel_transfer_question_cloud">तुम बंद करो और सूची से यह डाउनलोड निकालना चाहते हैं, आप सुनिश्चित हैं?</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="use_tpb">Use TPB</string>
     <string name="use_zooqle">Use Zooqle.com</string>
     <string name="use_yify">Use Yify</string>
+    <string name="use_one337x">Use 1337x</string>
     <string name="use_magnet_summary">Magnet based, works only on Wi-Fi</string>
     <string name="ringtone_not_set">Ringtone could not be set</string>
     <string name="search">Search</string>

--- a/android/res/xml/settings_search_engines.xml
+++ b/android/res/xml/settings_search_engines.xml
@@ -2,7 +2,7 @@
 <!--
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/android/res/xml/settings_search_engines.xml
+++ b/android/res/xml/settings_search_engines.xml
@@ -71,6 +71,10 @@
         android:layout="@layout/view_preference_search_engine"
         android:title="@string/use_yify" />
     <androidx.preference.CheckBoxPreference
+        android:key="frostwire.prefs.search.use_one337x"
+        android:layout="@layout/view_preference_search_engine"
+        android:title="@string/use_one337x" />
+    <androidx.preference.CheckBoxPreference
         android:key="frostwire.prefs.search.use_zooqle"
         android:layout="@layout/view_preference_search_engine"
         android:title="@string/use_zooqle" />

--- a/android/src/com/frostwire/android/core/Constants.java
+++ b/android/src/com/frostwire/android/core/Constants.java
@@ -1,6 +1,6 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2018, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/android/src/com/frostwire/android/core/Constants.java
+++ b/android/src/com/frostwire/android/core/Constants.java
@@ -79,6 +79,7 @@ public final class Constants {
     public static final String PREF_KEY_SEARCH_USE_APPIA = "frostwire.prefs.search.use_appia";
     public static final String PREF_KEY_SEARCH_USE_TPB = "frostwire.prefs.search.use_tpb";
     public static final String PREF_KEY_SEARCH_USE_YIFY = "frostwire.prefs.search.use_yify";
+    public static final String PREF_KEY_SEARCH_USE_ONE337X = "frostwire.prefs.search.use_one337x";
     public static final String PREF_KEY_SEARCH_USE_TORRENTSFM = "frostwire.prefs.search.use_torrentsfm";
     public static final String PREF_KEY_SEARCH_USE_TORRENTZ2 = "frostwire.prefs.search.use_torrentz2";
     public static final String PREF_KEY_SEARCH_USE_MAGNETDL = "frostwire.prefs.search.use_magnetdl";

--- a/android/src/com/frostwire/android/gui/SearchEngine.java
+++ b/android/src/com/frostwire/android/gui/SearchEngine.java
@@ -249,10 +249,33 @@ public abstract class SearchEngine {
     };
 
     public static final SearchEngine ONE337X = new SearchEngine("1337x", Constants.PREF_KEY_SEARCH_USE_ONE337X) {
+        private String domainName = null;
+
         @Override
         public SearchPerformer getPerformer(long token, String keywords) {
-            return new One337xSearchPerformer("www.1377x.to", token, keywords, DEFAULT_TIMEOUT);
-            // change www.1377x.to to other like www.1337x.gd, www.1337x.to or other proxy site etc
+            if (domainName == null) {
+                throw new RuntimeException("check your logic, this search performer has no domain name ready");
+            }
+            return new One337xSearchPerformer(domainName, token, keywords, DEFAULT_TIMEOUT);
+        }
+
+        protected void postInitWork() {
+            new Thread(() -> {
+                HttpClient httpClient = HttpClientFactory.getInstance(HttpClientFactory.HttpContext.SEARCH);
+                String[] mirrors = {
+                        "1337x.to",
+                        "1337xto.to",
+                        "www.1377x.to",
+                        "1337x.gd",
+                };
+                domainName = UrlUtils.getFastestMirrorDomain(httpClient, mirrors, 7000);
+            }
+            ).start();
+        }
+
+        @Override
+        protected boolean isReady() {
+            return domainName != null;
         }
     };
 

--- a/android/src/com/frostwire/android/gui/SearchEngine.java
+++ b/android/src/com/frostwire/android/gui/SearchEngine.java
@@ -29,6 +29,7 @@ import com.frostwire.search.frostclick.UserAgent;
 import com.frostwire.search.limetorrents.LimeTorrentsSearchPerformer;
 import com.frostwire.search.magnetdl.MagnetDLSearchPerformer;
 import com.frostwire.search.nyaa.NyaaSearchPerformer;
+import com.frostwire.search.one337x.One337xSearchPerformer;
 import com.frostwire.search.soundcloud.SoundcloudSearchPerformer;
 import com.frostwire.search.torlock.TorLockSearchPerformer;
 import com.frostwire.search.torrentdownloads.TorrentDownloadsSearchPerformer;
@@ -247,6 +248,14 @@ public abstract class SearchEngine {
         }
     };
 
+    public static final SearchEngine ONE337X = new SearchEngine("1337x", Constants.PREF_KEY_SEARCH_USE_ONE337X) {
+        @Override
+        public SearchPerformer getPerformer(long token, String keywords) {
+            return new One337xSearchPerformer("www.1377x.to", token, keywords, DEFAULT_TIMEOUT);
+            // change www.1377x.to to other like www.1337x.gd, www.1337x.to or other proxy site etc
+        }
+    };
+
     public static final SearchEngine TORRENTZ2 = new SearchEngine("Torrentz2", Constants.PREF_KEY_SEARCH_USE_TORRENTZ2) {
 
         @Override
@@ -267,6 +276,7 @@ public abstract class SearchEngine {
             MAGNETDL,
             TORRENTZ2,
             YIFY,
+            ONE337X,
             FROSTCLICK,
             ZOOQLE,
             TPB,

--- a/common/src/main/java/com/frostwire/search/one337x/One337xSearchPerformer.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xSearchPerformer.java
@@ -1,5 +1,5 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Himanshu Sharma (HimanshuSharma789)
  * Copyright (c) 2011-2018, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,6 @@
 
 package com.frostwire.search.one337x;
 
-import android.util.Log;
-
 import com.frostwire.search.CrawlableSearchResult;
 import com.frostwire.search.SearchMatcher;
 import com.frostwire.search.torrent.TorrentRegexSearchPerformer;
@@ -26,20 +24,17 @@ import com.frostwire.search.torrent.TorrentRegexSearchPerformer;
 /**
  * @author gubatron
  * @author aldenml
+ * @author HimanshuSharma789
  */
 public final class One337xSearchPerformer extends TorrentRegexSearchPerformer<One337xSearchResult> {
-    public static final String SEARCH_RESULTS_REGEX = "(?is)<a href=\"/torrent/(?<itemId>[0-9]*)/(?<htmlFileName>.*?)\">";
+    public static final String SEARCH_RESULTS_REGEX = "(?is)<a href=\"/torrent/(?<itemId>[0-9]*)/(?<htmlFileName>.*?)\">(?<displayName>.*?)</a>";
 
     public static final String TORRENT_DETAILS_PAGE_REGEX = "(?is)<div class=\"box-info-heading clearfix\">.*?" +
-            "<h1>(?<displayName>.*?)</h1>.*?" +
             "<a class=\"(.*)\" href=\"(?<magnet>.*?)\" onclick=\"(.*?)\">.*?" +
             "<strong>Language</strong> <span>(?<language>.*?)</span>.*?" +
             "<strong>Total size</strong> <span>(?<size>.*?)</span>.*?" +
             "<strong>Date uploaded</strong> <span>(?<creationDate>.*?)</span>.*?" +
             "<strong>Seeders</strong> <span class=\"seeds\">(?<seeds>[0-9]+)</span>";
-//            "<div class=\"torrent-image\">.*?<img src=\"(?<cover>.*?)\" alt";
-    // uncomment above code for thumbnail of each torrent
-    // commented because not all 1337x-torrent page have thumbnail
 
 
     private static final int MAX_RESULTS = 20;
@@ -57,12 +52,13 @@ public final class One337xSearchPerformer extends TorrentRegexSearchPerformer<On
     public CrawlableSearchResult fromMatcher(SearchMatcher matcher) {
         String itemId = matcher.group("itemId");
         String htmlFileName = matcher.group("htmlFileName");
-        return new One337xTempSearchResult(getDomainName(), itemId, htmlFileName);
+        String displayName = matcher.group("displayName");
+        return new One337xTempSearchResult(getDomainName(), itemId, htmlFileName, displayName);
     }
 
     @Override
     protected One337xSearchResult fromHtmlMatcher(CrawlableSearchResult sr, SearchMatcher matcher) {
-        return new One337xSearchResult(sr.getDetailsUrl(), matcher);
+        return new One337xSearchResult(sr.getDetailsUrl(), sr.getDisplayName(), matcher);
     }
 
     @Override

--- a/common/src/main/java/com/frostwire/search/one337x/One337xSearchPerformer.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xSearchPerformer.java
@@ -1,6 +1,6 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Himanshu Sharma (HimanshuSharma789)
- * Copyright (c) 2011-2018, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/frostwire/search/one337x/One337xSearchPerformer.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xSearchPerformer.java
@@ -1,0 +1,85 @@
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Copyright (c) 2011-2018, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.frostwire.search.one337x;
+
+import android.util.Log;
+
+import com.frostwire.search.CrawlableSearchResult;
+import com.frostwire.search.SearchMatcher;
+import com.frostwire.search.torrent.TorrentRegexSearchPerformer;
+
+/**
+ * @author gubatron
+ * @author aldenml
+ */
+public final class One337xSearchPerformer extends TorrentRegexSearchPerformer<One337xSearchResult> {
+    public static final String SEARCH_RESULTS_REGEX = "(?is)<a href=\"/torrent/(?<itemId>[0-9]*)/(?<htmlFileName>.*?)\">";
+
+    public static final String TORRENT_DETAILS_PAGE_REGEX = "(?is)<div class=\"box-info-heading clearfix\">.*?" +
+            "<h1>(?<displayName>.*?)</h1>.*?" +
+            "<a class=\"(.*)\" href=\"(?<magnet>.*?)\" onclick=\"(.*?)\">.*?" +
+            "<strong>Language</strong> <span>(?<language>.*?)</span>.*?" +
+            "<strong>Total size</strong> <span>(?<size>.*?)</span>.*?" +
+            "<strong>Date uploaded</strong> <span>(?<creationDate>.*?)</span>.*?" +
+            "<strong>Seeders</strong> <span class=\"seeds\">(?<seeds>[0-9]+)</span>";
+//            "<div class=\"torrent-image\">.*?<img src=\"(?<cover>.*?)\" alt";
+    // uncomment above code for thumbnail of each torrent
+    // commented because not all 1337x-torrent page have thumbnail
+
+
+    private static final int MAX_RESULTS = 20;
+
+    public One337xSearchPerformer(String domainName, long token, String keywords, int timeout) {
+        super(domainName, token, keywords, timeout, 1, 2 * MAX_RESULTS, MAX_RESULTS, SEARCH_RESULTS_REGEX, TORRENT_DETAILS_PAGE_REGEX);
+    }
+
+    @Override
+    protected String getUrl(int page, String encodedKeywords) {
+        return "https://" + getDomainName() + "/search/" + encodedKeywords + "/1/";
+    }
+
+    @Override
+    public CrawlableSearchResult fromMatcher(SearchMatcher matcher) {
+        String itemId = matcher.group("itemId");
+        String htmlFileName = matcher.group("htmlFileName");
+        return new One337xTempSearchResult(getDomainName(), itemId, htmlFileName);
+    }
+
+    @Override
+    protected One337xSearchResult fromHtmlMatcher(CrawlableSearchResult sr, SearchMatcher matcher) {
+        return new One337xSearchResult(sr.getDetailsUrl(), matcher);
+    }
+
+    @Override
+    protected boolean isValidHtml(String html) {
+        return html != null && !html.contains("Cloudflare");
+    }
+
+    @Override
+    protected int htmlPrefixOffset(String html) {
+        int offset = html.indexOf("<div class=\"col-9 page-content\">");
+        return offset > 0 ? offset : 0;
+    }
+
+    @Override
+    protected int htmlSuffixOffset(String html) {
+        int offset = html.indexOf("<div class=\"torrent-detail-info\"");
+        return offset > 0 ? offset : html.length();
+    }
+
+}

--- a/common/src/main/java/com/frostwire/search/one337x/One337xSearchResult.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xSearchResult.java
@@ -1,0 +1,173 @@
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.frostwire.search.one337x;
+
+import android.util.Log;
+
+import com.frostwire.search.PerformersHelper;
+import com.frostwire.search.SearchMatcher;
+import com.frostwire.search.torrent.AbstractTorrentSearchResult;
+
+import org.apache.commons.io.FilenameUtils;
+
+/**
+ * @author gubatron
+ * @author aldenml
+ */
+public final class One337xSearchResult extends AbstractTorrentSearchResult {
+
+//    private final String thumbnailUrl;
+    private final String filename;
+    private final String displayName;
+    private final String detailsUrl;
+    private final String infoHash;
+    private final double size;
+    private final long creationTime;
+    private final int seeds;
+    private final String magnetUrl;
+
+    public One337xSearchResult(String detailsUrl, SearchMatcher matcher) {
+        this.detailsUrl = detailsUrl;
+        this.displayName = buildDisplayName(matcher);
+        this.size = parseSize(matcher.group("size"));
+//        this.thumbnailUrl = buildThumbnailUrl(matcher.group("cover"));
+        this.creationTime = parseCreationTime(matcher.group("creationDate"));
+        this.seeds = parseSeeds(matcher.group("seeds"));
+        this.magnetUrl = matcher.group("magnet");
+        this.filename = buildFileName(detailsUrl);
+        this.infoHash = PerformersHelper.parseInfoHash(magnetUrl); // already comes in lowercase
+    }
+
+    private static String buildDisplayName(SearchMatcher matcher) {
+        String displayName = matcher.group("displayName");
+        String lang = matcher.group("language");
+
+        if (lang != null) {
+            displayName += " (" + lang + ")";
+        }
+        return displayName;
+    }
+
+    /*private static String buildThumbnailUrl(String str) {
+        if (str == null) {
+            return null;
+        }
+        return str.startsWith("//") ? "https:" + str : null;
+    }*/
+
+    private static String buildFileName(String detailsUrl) {
+        return FilenameUtils.getBaseName(detailsUrl) + ".torrent";
+    }
+
+    private static int parseSeeds(String group) {
+        try {
+            return Integer.parseInt(group);
+        } catch (Throwable e) {
+            return 0;
+        }
+    }
+
+    @Override
+    public double getSize() {
+        return size;
+    }
+
+    @Override
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    @Override
+    public String getTorrentUrl() {
+        return magnetUrl;
+    }
+
+    @Override
+    public String getSource() {
+        return "1337x";
+    }
+
+    @Override
+    public String getHash() {
+        return infoHash;
+    }
+
+    @Override
+    public int getSeeds() {
+        return seeds;
+    }
+
+    @Override
+    public String getDetailsUrl() {
+        return detailsUrl;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getFilename() {
+        return filename;
+    }
+
+    /*@Override
+    public String getThumbnailUrl() {
+        return thumbnailUrl;
+    }*/
+
+    private long parseCreationTime(String dateString) {
+        long result = System.currentTimeMillis();
+        try {
+            String[] ds = dateString.split(" ");
+            if (ds[1].contains("hour")) {
+                try {
+                    int hours = Integer.parseInt(ds[0]);
+                    return result - (hours * 60 * 60 * 1000L);
+                } catch (Exception ignored) {
+                }
+            }
+            if (ds[1].contains("year")) {
+                try {
+                    int years = Integer.parseInt(ds[0]);
+                    return result - (years * 365L * 24L * 60L * 60L * 1000L); // a year in milliseconds
+                } catch (Exception ignored) {
+                }
+            }
+            if (ds[1].contains("month")) {
+                try {
+                    int months = Integer.parseInt(ds[0]);
+                    return result - (months * 31L * 24L * 60L * 60L * 1000L); // a month in milliseconds
+                } catch (Exception ignored) {
+                }
+            }
+            if (ds[1].contains("minute")) {
+                try {
+                    int minutes = Integer.parseInt(ds[0]);
+                    return result - (minutes * 60L * 1000L); // a month in milliseconds
+                } catch (Exception ignored) {
+                }
+            }
+            return result;
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+        return result;
+    }
+}

--- a/common/src/main/java/com/frostwire/search/one337x/One337xSearchResult.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xSearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Himanshu Sharma (HimanshuSharma789)
  * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,6 @@
 
 package com.frostwire.search.one337x;
 
-import android.util.Log;
-
 import com.frostwire.search.PerformersHelper;
 import com.frostwire.search.SearchMatcher;
 import com.frostwire.search.torrent.AbstractTorrentSearchResult;
@@ -28,10 +26,10 @@ import org.apache.commons.io.FilenameUtils;
 /**
  * @author gubatron
  * @author aldenml
+ * @author HimanshuSharma789
  */
 public final class One337xSearchResult extends AbstractTorrentSearchResult {
 
-//    private final String thumbnailUrl;
     private final String filename;
     private final String displayName;
     private final String detailsUrl;
@@ -41,34 +39,16 @@ public final class One337xSearchResult extends AbstractTorrentSearchResult {
     private final int seeds;
     private final String magnetUrl;
 
-    public One337xSearchResult(String detailsUrl, SearchMatcher matcher) {
+    public One337xSearchResult(String detailsUrl, String displayName, SearchMatcher matcher) {
         this.detailsUrl = detailsUrl;
-        this.displayName = buildDisplayName(matcher);
+        this.displayName = displayName;
         this.size = parseSize(matcher.group("size"));
-//        this.thumbnailUrl = buildThumbnailUrl(matcher.group("cover"));
         this.creationTime = parseCreationTime(matcher.group("creationDate"));
         this.seeds = parseSeeds(matcher.group("seeds"));
         this.magnetUrl = matcher.group("magnet");
         this.filename = buildFileName(detailsUrl);
         this.infoHash = PerformersHelper.parseInfoHash(magnetUrl); // already comes in lowercase
     }
-
-    private static String buildDisplayName(SearchMatcher matcher) {
-        String displayName = matcher.group("displayName");
-        String lang = matcher.group("language");
-
-        if (lang != null) {
-            displayName += " (" + lang + ")";
-        }
-        return displayName;
-    }
-
-    /*private static String buildThumbnailUrl(String str) {
-        if (str == null) {
-            return null;
-        }
-        return str.startsWith("//") ? "https:" + str : null;
-    }*/
 
     private static String buildFileName(String detailsUrl) {
         return FilenameUtils.getBaseName(detailsUrl) + ".torrent";
@@ -126,11 +106,6 @@ public final class One337xSearchResult extends AbstractTorrentSearchResult {
     public String getFilename() {
         return filename;
     }
-
-    /*@Override
-    public String getThumbnailUrl() {
-        return thumbnailUrl;
-    }*/
 
     private long parseCreationTime(String dateString) {
         long result = System.currentTimeMillis();

--- a/common/src/main/java/com/frostwire/search/one337x/One337xSearchResult.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xSearchResult.java
@@ -1,6 +1,6 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Himanshu Sharma (HimanshuSharma789)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/frostwire/search/one337x/One337xTempSearchResult.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xTempSearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Himanshu Sharma (HimanshuSharma789)
  * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,25 +17,26 @@
 
 package com.frostwire.search.one337x;
 
-import android.util.Log;
-
 import com.frostwire.search.AbstractSearchResult;
 import com.frostwire.search.CrawlableSearchResult;
 
 /**
  * @author gubatron
  * @author aldenml
+ * @author HimanshuSharma789
  */
 final class One337xTempSearchResult extends AbstractSearchResult implements CrawlableSearchResult {
     private final String detailsUrl;
+    private final String displayName;
 
-    One337xTempSearchResult(String domainName, String itemId, String htmlFilename) {
+    One337xTempSearchResult(String domainName, String itemId, String htmlFilename, String displayName) {
         this.detailsUrl = "https://" + domainName + "/torrent/" + itemId + "/" + htmlFilename;
+        this.displayName = displayName;
     }
 
     @Override
     public String getDisplayName() {
-        return null;
+        return displayName;
     }
 
     @Override
@@ -45,7 +46,7 @@ final class One337xTempSearchResult extends AbstractSearchResult implements Craw
 
     @Override
     public String getSource() {
-        return null;
+        return "1337x";
     }
 
     @Override

--- a/common/src/main/java/com/frostwire/search/one337x/One337xTempSearchResult.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xTempSearchResult.java
@@ -1,0 +1,55 @@
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.frostwire.search.one337x;
+
+import android.util.Log;
+
+import com.frostwire.search.AbstractSearchResult;
+import com.frostwire.search.CrawlableSearchResult;
+
+/**
+ * @author gubatron
+ * @author aldenml
+ */
+final class One337xTempSearchResult extends AbstractSearchResult implements CrawlableSearchResult {
+    private final String detailsUrl;
+
+    One337xTempSearchResult(String domainName, String itemId, String htmlFilename) {
+        this.detailsUrl = "https://" + domainName + "/torrent/" + itemId + "/" + htmlFilename;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getDetailsUrl() {
+        return detailsUrl;
+    }
+
+    @Override
+    public String getSource() {
+        return null;
+    }
+
+    @Override
+    public boolean isComplete() {
+        return false;
+    }
+}

--- a/common/src/main/java/com/frostwire/search/one337x/One337xTempSearchResult.java
+++ b/common/src/main/java/com/frostwire/search/one337x/One337xTempSearchResult.java
@@ -1,6 +1,6 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Himanshu Sharma (HimanshuSharma789)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/desktop/src/com/limegroup/gnutella/gui/search/SearchEngine.java
+++ b/desktop/src/com/limegroup/gnutella/gui/search/SearchEngine.java
@@ -153,8 +153,24 @@ public abstract class SearchEngine {
     };
 
     private static final SearchEngine ONE337X = new SearchEngine(ONE337X_ID, "1337x", SearchEnginesSettings.ONE337X_SEARCH_ENABLED, "www.1377x.to") {
+        protected void postInitWork() {
+            new Thread(() -> {
+                HttpClient httpClient = HttpClientFactory.getInstance(HttpClientFactory.HttpContext.SEARCH);
+                String[] mirrors = {
+                        "1337x.to",
+                        "1337xto.to",
+                        "www.1377x.to",
+                        "1337x.gd",
+                };
+                ONE337X._domainName = UrlUtils.getFastestMirrorDomain(httpClient, mirrors, 6000);
+            }
+            ).start();
+        }
         @Override
         public SearchPerformer getPerformer(long token, String keywords) {
+            if (!isReady()) {
+                throw new RuntimeException("Check your logic, a search performer that's not ready should not be in the list of performers yet.");
+            }
             return new One337xSearchPerformer(ONE337X.getDomainName(), token, keywords, DEFAULT_TIMEOUT);
         }
     };

--- a/desktop/src/com/limegroup/gnutella/gui/search/SearchEngine.java
+++ b/desktop/src/com/limegroup/gnutella/gui/search/SearchEngine.java
@@ -1,6 +1,6 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2019, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.frostwire.search.frostclick.UserAgent;
 import com.frostwire.search.limetorrents.LimeTorrentsSearchPerformer;
 import com.frostwire.search.magnetdl.MagnetDLSearchPerformer;
 import com.frostwire.search.nyaa.NyaaSearchPerformer;
+import com.frostwire.search.one337x.One337xSearchPerformer;
 import com.frostwire.search.soundcloud.SoundcloudSearchPerformer;
 import com.frostwire.search.torlock.TorLockSearchPerformer;
 import com.frostwire.search.torrentdownloads.TorrentDownloadsSearchPerformer;
@@ -56,6 +57,7 @@ public abstract class SearchEngine {
     private static final int TORLOCK_ID = 14;
     private static final int EZTV_ID = 15;
     private static final int YIFI_ID = 17;
+    private static final int ONE337X_ID = 26;
     private static final int TORRENTDOWNLOADS_ID = 19;
     private static final int LIMETORRENTS_ID = 20;
     private static final int ZOOQLE_ID = 21;
@@ -149,6 +151,14 @@ public abstract class SearchEngine {
             return new YifySearchPerformer(YIFY.getDomainName(), token, keywords, DEFAULT_TIMEOUT);
         }
     };
+
+    private static final SearchEngine ONE337X = new SearchEngine(ONE337X_ID, "1337x", SearchEnginesSettings.ONE337X_SEARCH_ENABLED, "www.1377x.to") {
+        @Override
+        public SearchPerformer getPerformer(long token, String keywords) {
+            return new One337xSearchPerformer(ONE337X.getDomainName(), token, keywords, DEFAULT_TIMEOUT);
+        }
+    };
+
     private static final SearchEngine ZOOQLE = new SearchEngine(ZOOQLE_ID, "Zooqle", SearchEnginesSettings.ZOOQLE_SEARCH_ENABLED, "zooqle.com") {
         @Override
         public SearchPerformer getPerformer(long token, String keywords) {
@@ -198,6 +208,7 @@ public abstract class SearchEngine {
                 TORLOCK,
                 NYAA,
                 YIFY,
+                ONE337X,
                 EZTV,
                 TORRENTDOWNLOADS,
                 LIMETORRENTS);

--- a/desktop/src/com/limegroup/gnutella/settings/SearchEnginesSettings.java
+++ b/desktop/src/com/limegroup/gnutella/settings/SearchEnginesSettings.java
@@ -1,6 +1,6 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ public class SearchEnginesSettings extends LimeProps {
     public static final BooleanSetting LIMETORRENTS_SEARCH_ENABLED = FACTORY.createBooleanSetting("LIMETORRENTS_SEARCH_ENABLED", true);
     public static final BooleanSetting EZTV_SEARCH_ENABLED = FACTORY.createBooleanSetting("EZTV_SEARCH_ENABLED", true);
     public static final BooleanSetting YIFY_SEARCH_ENABLED = FACTORY.createBooleanSetting("YIFY_SEARCH_ENABLED", true);
+    public static final BooleanSetting ONE337X_SEARCH_ENABLED = FACTORY.createBooleanSetting("ONE337X_SEARCH_ENABLED", true);
     public static final BooleanSetting ZOOQLE_SEARCH_ENABLED = FACTORY.createBooleanSetting("ZOOQLE_SEARCH_ENABLED", true);
     public static final BooleanSetting TORRENTZ2_SEARCH_ENABLED = FACTORY.createBooleanSetting("TORRENTZ2_SEARCH_ENABLED", true);
     public static final BooleanSetting NYAA_SEARCH_ENABLED = FACTORY.createBooleanSetting("NYAA_SEARCH_ENABLED", true);

--- a/desktop/src/test/java/com/frostwire/tests/One337xSearchPerformerTest.java
+++ b/desktop/src/test/java/com/frostwire/tests/One337xSearchPerformerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Himanshu Sharma (HimanshuSharma789)
+ * Copyright (c) 2011-2018, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.frostwire.tests;
+
+import com.frostwire.regex.Matcher;
+import com.frostwire.regex.Pattern;
+import com.frostwire.search.SearchMatcher;
+import com.frostwire.search.one337x.One337xSearchPerformer;
+import com.frostwire.search.one337x.One337xSearchResult;
+import com.frostwire.util.ThreadPool;
+import com.frostwire.util.http.HttpClient;
+import com.frostwire.util.http.OKHTTPClient;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+public final class One337xSearchPerformerTest {
+    public static void main(String[] args) throws Throwable {
+        String TEST_SEARCH_TERM = "avengers";
+        HttpClient httpClient = new OKHTTPClient(new ThreadPool("testPool", 4, new LinkedBlockingQueue<>(), false));
+        String fileStr = httpClient.get("https://www.1377x.to/search/" + TEST_SEARCH_TERM+"/1/");
+        Pattern searchResultsDetailURLPattern = Pattern.compile(One337xSearchPerformer.SEARCH_RESULTS_REGEX);
+        Pattern detailPagePattern = Pattern.compile(One337xSearchPerformer.TORRENT_DETAILS_PAGE_REGEX);
+        Matcher searchResultsMatcher = searchResultsDetailURLPattern.matcher(fileStr);
+        int found = 0;
+        while (searchResultsMatcher.find()) {
+            found++;
+            System.out.println("\nfound " + found);
+            System.out.println("result_url: [" + searchResultsMatcher.group(1) + "]");
+            String detailUrl = "https://www.1377x.to/torrent/" + searchResultsMatcher.group("itemId") + "/" + searchResultsMatcher.group("htmlFileName");
+            String displayName = searchResultsMatcher.group("displayName");
+            System.out.println("Fetching details from " + detailUrl + " ....");
+            long start = System.currentTimeMillis();
+            String detailPage = httpClient.get(detailUrl, 5000);
+            if (detailPage == null) {
+                System.out.println("Error fetching from " + detailUrl);
+                continue;
+            }
+            long downloadTime = System.currentTimeMillis() - start;
+            System.out.println("Downloaded " + detailPage.length() + " bytes in " + downloadTime + "ms");
+            SearchMatcher sm = new SearchMatcher(detailPagePattern.matcher(detailPage));
+            if (sm.find()) {
+                System.out.println("displayname: [" + displayName + "]");
+                System.out.println("size: [" + sm.group("size") + "]");
+                System.out.println("creationDate: [" + sm.group("creationDate") + "]");
+                System.out.println("seeds: [" + sm.group("seeds") + "]");
+                System.out.println("magnet: [" + sm.group("magnet") + "]");
+                One337xSearchResult sr = new One337xSearchResult(detailUrl, displayName, sm);
+                System.out.println(sr);
+            } else {
+                System.out.println("Detail page search matcher failed, check TORRENT_DETAILS_PAGE_REGEX");
+            }
+            System.out.println("===");
+            System.out.println("Sleeping 5 seconds...");
+            Thread.sleep(5000);
+        }
+        System.out.println("-done-");
+        if (found == 0) {
+            System.out.println(fileStr);
+        }
+    }
+}

--- a/desktop/src/test/java/com/frostwire/tests/One337xSearchPerformerTest.java
+++ b/desktop/src/test/java/com/frostwire/tests/One337xSearchPerformerTest.java
@@ -1,6 +1,6 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Himanshu Sharma (HimanshuSharma789)
- * Copyright (c) 2011-2018, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 public final class One337xSearchPerformerTest {
     public static void main(String[] args) throws Throwable {
-        String TEST_SEARCH_TERM = "avengers";
+        String TEST_SEARCH_TERM = "foo";
         HttpClient httpClient = new OKHTTPClient(new ThreadPool("testPool", 4, new LinkedBlockingQueue<>(), false));
-        String fileStr = httpClient.get("https://www.1377x.to/search/" + TEST_SEARCH_TERM+"/1/");
+        String fileStr = httpClient.get("https://www.1377x.to/search/" + TEST_SEARCH_TERM + "/1/");
         Pattern searchResultsDetailURLPattern = Pattern.compile(One337xSearchPerformer.SEARCH_RESULTS_REGEX);
         Pattern detailPagePattern = Pattern.compile(One337xSearchPerformer.TORRENT_DETAILS_PAGE_REGEX);
         Matcher searchResultsMatcher = searchResultsDetailURLPattern.matcher(fileStr);


### PR DESCRIPTION
Add a **popular torrent search** - [**1337x**](https://1337x.gd) to the search engine in the android app.
Replicated "yify" search package,  modified a little and added 1337x search support.

Added 3 files in **one337x package** in search:
- One337xSearchPerformer.java
- One337xSearchResult.java
- One337xTempSearchResult.java

Modified 4 files:
- SearchEngine.java
- Constants.java
- settings_search_engines.xml
- strings.xml

works perfectly in MIUI11, android 7.1.1, android 9

My first contribution on GITHUB. Hope you would love it 😄  and 1337x ❤️ .

<img src="https://user-images.githubusercontent.com/32963903/86368580-f800aa00-bc9a-11ea-853e-eb88f73afb6d.jpg" widht="150" height="600">

