### PR TITLE
Fixed Torrentz2 age (i.e. creationTime)

### DIFF
--- a/common/src/main/java/com/frostwire/search/torrentz2/Torrentz2SearchPerformer.java
+++ b/common/src/main/java/com/frostwire/search/torrentz2/Torrentz2SearchPerformer.java
@@ -38,7 +38,7 @@ public class Torrentz2SearchPerformer extends TorrentSearchPerformer {
         //https://torrentz2.eu
         //https://torrentz2.unblockninja.com/
         super("torrentz2.unblockninja.com/", token, keywords, timeout, 1, 0);
-        pattern = Pattern.compile("(?is)<dl><dt><a href='(?<infohash>[a-f0-9]{40})'>(?<filename>.*?)</a>.*?<span class='a'><span title='.*?'>(?<age>.*?)</span><span class='s'>(?<filesize>.*?) (?<unit>[BKMGTPEZY]+)</span> <span class='u'>(?<seeds>\\d+)</span><span class='d'>.*?");
+        pattern = Pattern.compile("(?is)<dl><dt><a href='(?<infohash>[a-f0-9]{40})'>(?<filename>.*?)</a>.*?<span class='a'><span title='.*?'>(?<age>.*?)</span>.*?<span class='s'>(?<filesize>.*?) (?<unit>[BKMGTPEZY]+)</span> <span class='u'>(?<seeds>\\d+)</span><span class='d'>.*?");
     }
 
     @Override

--- a/common/src/main/java/com/frostwire/search/torrentz2/Torrentz2SearchResult.java
+++ b/common/src/main/java/com/frostwire/search/torrentz2/Torrentz2SearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,6 +99,7 @@ public final class Torrentz2SearchResult extends AbstractTorrentSearchResult {
         long result = System.currentTimeMillis();
         try {
             String[] ds = dateString.split(" ");
+            ds[1] = ds[1].toLowerCase();
             if (ds[1].contains("hour")) {
                 try {
                     int hours = Integer.parseInt(ds[0]);
@@ -106,14 +107,14 @@ public final class Torrentz2SearchResult extends AbstractTorrentSearchResult {
                 } catch (Exception ignored) {
                 }
             }
-            if (ds[1].contains("Year")) {
+            if (ds[1].contains("year")) {
                 try {
                     int years = Integer.parseInt(ds[0]);
                     return result - (years * 365L * 24L * 60L * 60L * 1000L); // a year in milliseconds
                 } catch (Exception ignored) {
                 }
             }
-            if (ds[1].contains("Month")) {
+            if (ds[1].contains("month")) {
                 try {
                     int months = Integer.parseInt(ds[0]);
                     return result - (months * 31L * 24L * 60L * 60L * 1000L); // a month in milliseconds
@@ -123,14 +124,14 @@ public final class Torrentz2SearchResult extends AbstractTorrentSearchResult {
             if (ds[1].contains("week")) {
                 try {
                     int weeks = Integer.parseInt(ds[0]);
-                    return result - (weeks * 7L * 24L * 60L * 60L * 1000L); // a month in milliseconds
+                    return result - (weeks * 7L * 24L * 60L * 60L * 1000L); // a week in milliseconds
                 } catch (Exception ignored) {
                 }
             }
             if (ds[1].contains("day")) {
                 try {
                     int days = Integer.parseInt(ds[0]);
-                    return result - (days * 24L * 60L * 60L * 1000L); // a month in milliseconds
+                    return result - (days * 24L * 60L * 60L * 1000L); // a day in milliseconds
                 } catch (Exception ignored) {
                 }
             }

--- a/common/src/main/java/com/frostwire/search/torrentz2/Torrentz2SearchResult.java
+++ b/common/src/main/java/com/frostwire/search/torrentz2/Torrentz2SearchResult.java
@@ -96,38 +96,43 @@ public final class Torrentz2SearchResult extends AbstractTorrentSearchResult {
     }
 
     private long parseCreationTime(String dateString) {
-        long result = 0;
+        long result = System.currentTimeMillis();
         try {
             String[] ds = dateString.split(" ");
-            if (ds[1].contains("hours")) {
+            if (ds[1].contains("hour")) {
                 try {
                     int hours = Integer.parseInt(ds[0]);
                     return result - (hours * 60 * 60 * 1000L);
                 } catch (Exception ignored) {
                 }
             }
-            if (ds[1].contains("years")) {
+            if (ds[1].contains("Year")) {
                 try {
                     int years = Integer.parseInt(ds[0]);
                     return result - (years * 365L * 24L * 60L * 60L * 1000L); // a year in milliseconds
                 } catch (Exception ignored) {
                 }
             }
-            if (ds[1].contains("year")) {
-                try {
-                    return result - (365L * 24L * 60L * 60L * 1000L); // a year in milliseconds
-                } catch (Exception ignored) {
-                }
-            }
-            if (ds[1].contains("months")) {
+            if (ds[1].contains("Month")) {
                 try {
                     int months = Integer.parseInt(ds[0]);
                     return result - (months * 31L * 24L * 60L * 60L * 1000L); // a month in milliseconds
                 } catch (Exception ignored) {
                 }
             }
-            if (dateString.contains("1 month")) {
-                return result - 31L * 24L * 60L * 60L * 1000L; // a month in milliseconds
+            if (ds[1].contains("week")) {
+                try {
+                    int weeks = Integer.parseInt(ds[0]);
+                    return result - (weeks * 7L * 24L * 60L * 60L * 1000L); // a month in milliseconds
+                } catch (Exception ignored) {
+                }
+            }
+            if (ds[1].contains("day")) {
+                try {
+                    int days = Integer.parseInt(ds[0]);
+                    return result - (days * 24L * 60L * 60L * 1000L); // a month in milliseconds
+                } catch (Exception ignored) {
+                }
             }
             return result;
         } catch (Throwable t) {


### PR DESCRIPTION
Fixing torrentz2 search age (i.e. creationTime). Previously torrentz2 do not show the creationTime (age of torrent file) in the app.

- **Fixed the REGEX pattern** to extract the Date (in **Torrentz2SearchPerformer**)
[earlier "\<span\>" tag was concatenated along with the Date] So, i fixed that issue.

- Optimized and fixed the **parsing of creationTime** (in **Torrentz2SearchResult**)
