### PR TITLE
[common] Use continue instead of return if setupSaveDir() returns null

### DIFF
--- a/common/src/main/java/com/frostwire/bittorrent/BTEngine.java
+++ b/common/src/main/java/com/frostwire/bittorrent/BTEngine.java
@@ -411,7 +411,7 @@ public final class BTEngine extends SessionManager {
                         File savePath = readSavePath(infoHash);
                         if (setupSaveDir(savePath) == null) {
                             LOG.warn("Can't create data dir or mount point is not accessible");
-                            return;
+                            continue;
                         }
                         restoreDownloadsQueue.add(new RestoreDownloadTask(t, null, null, resumeFile));
                     }


### PR DESCRIPTION
When using return, if a file or folder was manually deleted, all
remaining torrents in the loop were skipped.