### PR TITLE
Clean up Android Gradle config files

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
-distributionUrl=https://services.gradle.org/distributions/gradle-8.3-all.zip
 # Project-wide Gradle settings.
 
 # IDE (e.g. Android Studio) users:
@@ -19,9 +18,8 @@ org.gradle.jvmargs=-Xmx2560m -XX:+UseParallelGC
 org.gradle.parallel=false
 org.gradle.daemon=false
 
-# Jul 12 2019 - To solve Manifest merger failed Attribute application@appComponentFactory value=(android.support.v4.app.CoreComponentFactory) from [com.android.support:support-compat:28.0.0] AndroidManifest.xml:22:18-91 is also present at [androidx.core:core:1.0.0] AndroidManifest.xml:22:18-86
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 
 # Aug 23 2019, to solve "API 'variant.getAssemble()' is obsolete and has been replaced with 'variant.getAssembleProvider()'"
 android.debug.obsoleteApi=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -4,8 +4,3 @@ distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-org.gradle.daemon=false
-org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx2560m -XX\:MaxPermSize\=1024m -XX\:+UseParallelGC
-android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
Small clean up of gradle config files in the Android project. 

I removed properties under `gradle-wrapper.properties` that are not relevant to that scope and that should only be declared in the root `gradle.properties` of the project. 

I also disabled the Jetifier option because it is no longer needed for this project. Enabling Jetifier was required only in the distant past for projects that used legacy libraries that have not been migrated to use AndroidX. Enabling Jetifier means slower build speeds, thus I disabled it. 