### PR TITLE
Night theme rebased by gubatron

### DIFF
--- a/android/apollo/res/layout-v16/notification_template_expanded_base.xml
+++ b/android/apollo/res/layout-v16/notification_template_expanded_base.xml
@@ -15,11 +15,12 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="128.0dip"
-    android:background="@android:color/white"
-    tools:ignore="ContentDescription" >
+    android:background="@color/app_background_body_light"
+    tools:ignore="ContentDescription">
 
     <!-- The height cannot be specified any other way. It must read "128.0dip" and cannot be referenced. I think it's a bug. -->
 
@@ -41,7 +42,7 @@
         android:divider="?android:listDivider"
         android:dividerPadding="@dimen/notification_expanded_buttons_divider_padding"
         android:gravity="center_vertical"
-        android:orientation="horizontal" >
+        android:orientation="horizontal">
 
         <ImageButton
             android:id="@+id/notification_expanded_base_previous"
@@ -51,7 +52,8 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/notification_expanded_button_padding"
             android:scaleType="fitCenter"
-            android:src="@drawable/btn_notification_playback_previous" />
+            android:src="@drawable/btn_notification_playback_previous"
+            app:tint="@color/app_icon_primary" />
 
         <ImageButton
             android:id="@+id/notification_expanded_base_play"
@@ -61,7 +63,8 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/notification_expanded_button_padding"
             android:scaleType="fitCenter"
-            android:src="@drawable/btn_notification_playback_pause" />
+            android:src="@drawable/btn_notification_playback_pause"
+            app:tint="@color/app_icon_primary"/>
 
         <ImageButton
             android:id="@+id/notification_expanded_base_next"
@@ -71,7 +74,8 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/notification_expanded_button_padding"
             android:scaleType="fitCenter"
-            android:src="@drawable/btn_notification_playback_next" />
+            android:src="@drawable/btn_notification_playback_next"
+            app:tint="@color/app_icon_primary"/>
     </LinearLayout>
 
     <ImageButton
@@ -82,7 +86,8 @@
         android:layout_alignParentTop="true"
         android:background="?android:selectableItemBackground"
         android:padding="@dimen/notification_expanded_collapse_padding"
-        android:src="@drawable/btn_notification_collapse" />
+        android:src="@drawable/btn_notification_collapse"
+        app:tint="@color/app_icon_primary"/>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -98,17 +103,19 @@
         <TextView
             android:id="@+id/notification_expanded_base_line_one"
             style="@style/NotificationText"
-            android:textColor="@color/black"
+            android:textColor="@color/app_text_primary"
             android:textAppearance="@android:style/TextAppearance.StatusBar.EventContent.Title" />
 
         <TextView
             android:id="@+id/notification_expanded_base_line_two"
             style="@style/NotificationText"
+            android:textColor="@color/app_text_primary"
             android:textAppearance="@android:style/TextAppearance.StatusBar.EventContent" />
 
         <TextView
             android:id="@+id/notification_expanded_base_line_three"
             style="@style/NotificationText"
+            android:textColor="@color/app_text_primary"
             android:textAppearance="@android:style/TextAppearance.StatusBar.EventContent" />
     </LinearLayout>
 

--- a/android/apollo/res/layout/activity_base.xml
+++ b/android/apollo/res/layout/activity_base.xml
@@ -36,7 +36,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dip"
         android:layout_weight="1"
-        android:background="@color/app_background_white" />
+        android:background="@color/app_background_main" />
 
     <include layout="@layout/bottom_action_bar" />
 

--- a/android/apollo/res/layout/activity_player_base.xml
+++ b/android/apollo/res/layout/activity_player_base.xml
@@ -92,7 +92,7 @@
                     android:layout_height="match_parent"
                     android:background="@drawable/btn_switch_queue"
                     android:visibility="visible"
-                    android:tint="@color/app_icon_primary"/>
+                    app:tint="@color/app_icon_primary"/>
             </FrameLayout>
         </LinearLayout>
 

--- a/android/apollo/res/layout/activity_player_base.xml
+++ b/android/apollo/res/layout/activity_player_base.xml
@@ -17,7 +17,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:background="@color/app_background_body_light"
         android:orientation="vertical">
 
     <include layout="@layout/toolbar_main" />

--- a/android/apollo/res/layout/activity_player_base.xml
+++ b/android/apollo/res/layout/activity_player_base.xml
@@ -83,7 +83,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:contentDescription="@null" />
+                    android:contentDescription="@null"
+                    app:tint="@color/app_icon_primary"/>
 
                 <com.andrew.apollo.widgets.SquareImageView
                     android:id="@+id/audio_player_switch_album_art"
@@ -91,7 +92,7 @@
                     android:layout_height="match_parent"
                     android:background="@drawable/btn_switch_queue"
                     android:visibility="visible"
-                    android:tint="@color/app_icon_primary"/>
+                    app:tint="@color/app_icon_primary"/>
             </FrameLayout>
         </LinearLayout>
 

--- a/android/apollo/res/layout/activity_player_base.xml
+++ b/android/apollo/res/layout/activity_player_base.xml
@@ -92,7 +92,7 @@
                     android:layout_height="match_parent"
                     android:background="@drawable/btn_switch_queue"
                     android:visibility="visible"
-                    app:tint="@color/app_icon_primary"/>
+                    android:tint="@color/app_icon_primary"/>
             </FrameLayout>
         </LinearLayout>
 

--- a/android/apollo/res/layout/activity_player_base.xml
+++ b/android/apollo/res/layout/activity_player_base.xml
@@ -90,7 +90,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:background="@drawable/btn_switch_queue"
-                    android:visibility="visible" />
+                    android:visibility="visible"
+                    android:tint="@color/app_icon_primary"/>
             </FrameLayout>
         </LinearLayout>
 

--- a/android/apollo/res/layout/activity_player_base.xml
+++ b/android/apollo/res/layout/activity_player_base.xml
@@ -38,7 +38,7 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/audio_player_header_height"
             android:layout_alignParentTop="true"
-            android:background="@color/basic_white"
+            android:background="@color/basic_background"
             android:baselineAligned="false"
             android:orientation="horizontal">
 

--- a/android/apollo/res/layout/activity_profile_base.xml
+++ b/android/apollo/res/layout/activity_profile_base.xml
@@ -21,7 +21,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/app_background_white"
+    android:background="@color/app_background_main"
     android:orientation="vertical">
 
     <include layout="@layout/toolbar_main" />

--- a/android/apollo/res/layout/audio_player_controls.xml
+++ b/android/apollo/res/layout/audio_player_controls.xml
@@ -45,7 +45,8 @@
             android:layout_gravity="center"
             android:background="@null"
             android:scaleType="centerInside"
-            android:src="@drawable/btn_playback_previous" />
+            android:src="@drawable/btn_playback_previous"
+            android:tint="@color/app_icon_primary"/>
     </FrameLayout>
 
     <FrameLayout
@@ -77,7 +78,8 @@
             android:layout_gravity="center"
             android:background="@null"
             android:scaleType="centerInside"
-            android:src="@drawable/btn_playback_next" />
+            android:src="@drawable/btn_playback_next"
+            android:tint="@color/app_icon_primary"/>
     </FrameLayout>
 
     <FrameLayout

--- a/android/apollo/res/layout/audio_player_controls.xml
+++ b/android/apollo/res/layout/audio_player_controls.xml
@@ -63,7 +63,8 @@
             android:contentDescription="@string/accessibility_play"
             android:focusable="true"
             android:scaleType="centerInside"
-            android:src="@drawable/btn_playback_play" />
+            android:src="@drawable/btn_playback_play"
+            android:tint="@color/app_icon_primary"/>
     </FrameLayout>
 
     <FrameLayout

--- a/android/apollo/res/layout/edit_track_list_item.xml
+++ b/android/apollo/res/layout/edit_track_list_item.xml
@@ -15,7 +15,8 @@
   limitations under the License.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
     android:layout_height="@dimen/item_normal_height"
     android:background="@drawable/listview_item_background_selector">
 
@@ -24,7 +25,8 @@
         android:layout_width="@dimen/drag_and_drop_handle"
         android:layout_height="wrap_content"
         android:scaleType="centerInside"
-        android:src="@drawable/playlist_tile_normal"/>
+        android:src="@drawable/playlist_tile_normal"
+        app:tint="@color/app_icon_primary" />
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/android/apollo/res/layout/fragment_music_browser_phone.xml
+++ b/android/apollo/res/layout/fragment_music_browser_phone.xml
@@ -36,7 +36,7 @@
                 style="@style/AppTabLayout"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:background="@color/app_background"
+                android:background="@color/app_background_color"
                 app:tabPaddingStart="20dp"
                 app:tabPaddingEnd="20dp"
                 app:tabMode="scrollable" />

--- a/android/apollo/res/layout/grid_items_normal.xml
+++ b/android/apollo/res/layout/grid_items_normal.xml
@@ -36,7 +36,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:maxLines="2"
-            android:textColor="@color/app_text_primary"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_x_medium"
             android:textStyle="bold" />
 
@@ -46,7 +46,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/line_one"
             android:maxLines="1"
-            android:textColor="@color/app_text_secondary"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_small" />
     </RelativeLayout>
 

--- a/android/apollo/res/layout/grid_items_normal.xml
+++ b/android/apollo/res/layout/grid_items_normal.xml
@@ -36,7 +36,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:maxLines="2"
-            android:textColor="@color/app_text_white"
+            android:textColor="@color/app_text_primary"
             android:textSize="@dimen/text_x_medium"
             android:textStyle="bold" />
 
@@ -46,7 +46,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/line_one"
             android:maxLines="1"
-            android:textColor="@color/app_text_white"
+            android:textColor="@color/app_text_secondary"
             android:textSize="@dimen/text_small" />
     </RelativeLayout>
 

--- a/android/apollo/res/layout/grid_items_normal.xml
+++ b/android/apollo/res/layout/grid_items_normal.xml
@@ -36,7 +36,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:maxLines="2"
-            android:textColor="@color/white"
+            android:textColor="@color/app_text_primary"
             android:textSize="@dimen/text_x_medium"
             android:textStyle="bold" />
 
@@ -46,7 +46,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/line_one"
             android:maxLines="1"
-            android:textColor="@color/transparent_white"
+            android:textColor="@color/app_text_secondary"
             android:textSize="@dimen/text_small" />
     </RelativeLayout>
 

--- a/android/apollo/res/layout/list_base.xml
+++ b/android/apollo/res/layout/list_base.xml
@@ -38,7 +38,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center_vertical"
-        android:background="@color/app_background_white"
+        android:background="@color/app_background_main"
         android:cacheColorHint="@color/transparent"
         android:divider="@color/app_divider"
         android:dividerHeight="1dp"

--- a/android/apollo/res/layout/new_playlist_list_item.xml
+++ b/android/apollo/res/layout/new_playlist_list_item.xml
@@ -18,6 +18,7 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -29,7 +30,7 @@
         android:gravity="center_vertical"
         android:minHeight="@dimen/item_normal_height"
         android:paddingLeft="@dimen/list_simple_horizontal_padding"
-        android:paddingRight="@dimen/list_simple_horizontal_padding" >
+        android:paddingRight="@dimen/list_simple_horizontal_padding">
 
         <TextView
             android:layout_width="match_parent"
@@ -49,7 +50,8 @@
             android:layout_height="match_parent"
             android:layout_alignParentLeft="true"
             android:layout_marginRight="12dp"
-            android:src="@drawable/contextmenu_icon_playlist_add_dark" />
+            android:src="@drawable/contextmenu_icon_playlist_add_dark"
+            app:tint="@color/app_icon_primary" />
 
     </RelativeLayout>
 

--- a/android/apollo/res/layout/notification_template_base.xml
+++ b/android/apollo/res/layout/notification_template_base.xml
@@ -20,7 +20,7 @@
     android:layout_height="match_parent"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:background="@android:color/white"
+    android:background="@color/app_background_main"
     tools:ignore="ContentDescription" >
 
     <ImageView

--- a/android/apollo/res/values/styles.xml
+++ b/android/apollo/res/values/styles.xml
@@ -47,21 +47,25 @@
     <style name="NotificationAction.Previous" parent="@style/NotificationAction">
         <item name="android:src">@drawable/btn_notification_playback_previous</item>
         <item name="android:visibility">gone</item>
+        <item name="tint">@color/app_icon_primary</item>
         <item name="android:contentDescription">@string/accessibility_prev</item>
     </style>
 
     <style name="NotificationAction.Play" parent="@style/NotificationAction">
         <item name="android:src">@drawable/btn_notification_playback_play</item>
+        <item name="tint">@color/app_icon_primary</item>
         <item name="android:contentDescription">@string/accessibility_play</item>
     </style>
 
     <style name="NotificationAction.Next" parent="@style/NotificationAction">
         <item name="android:src">@drawable/btn_notification_playback_next</item>
         <item name="android:contentDescription">@string/accessibility_next</item>
+        <item name="tint">@color/app_icon_primary</item>
     </style>
 
     <style name="NotificationAction.Collapse" parent="@style/NotificationAction">
         <item name="android:src">@drawable/btn_notification_collapse</item>
+        <item name="tint">@color/app_icon_primary</item>
     </style>
 
     <!-- Bottom Action Bar TextViews -->

--- a/android/apollo/res/values/themeconfig.xml
+++ b/android/apollo/res/values/themeconfig.xml
@@ -29,11 +29,11 @@
     <!-- Now playing -->
     <color name="audio_player_current_time">#ff000000</color>
     <color name="audio_player_total_time">#ff000000</color>
-    <color name="audio_player_line_one">#ff000000</color>
+    <color name="audio_player_line_one">@color/basic_yellow</color>
     <color name="audio_player_line_two">#ff000000</color>
 
     <!-- Bottom action bar -->
-    <color name="bottom_action_bar">@color/app_background_dark_highlight</color>
+    <color name="bottom_action_bar">@color/app_background_color_dark_highlight</color>
     <color name="bab_line_one">@color/white</color>
     <color name="bab_line_two">@color/transparent_white</color>
 

--- a/android/apollo/res/values/themeconfig.xml
+++ b/android/apollo/res/values/themeconfig.xml
@@ -19,7 +19,7 @@
     <color name="action_bar">@color/action_bar_color</color>
 
     <!-- The action bar title color -->
-    <color name="action_bar_title">@color/white</color>
+    <color name="action_bar_title">@color/app_text_white</color>
 
     <!-- The action bar sub title color -->
 
@@ -29,8 +29,8 @@
     <!-- Now playing -->
     <color name="audio_player_current_time">#ff000000</color>
     <color name="audio_player_total_time">#ff000000</color>
-    <color name="audio_player_line_one">@color/basic_yellow</color>
-    <color name="audio_player_line_two">#ff000000</color>
+    <color name="audio_player_line_one">@color/app_text_primary</color>
+    <color name="audio_player_line_two">@color/app_text_primary</color>
 
     <!-- Bottom action bar -->
     <color name="bottom_action_bar">@color/app_background_color_dark_highlight</color>

--- a/android/apollo/res/values/themeconfig.xml
+++ b/android/apollo/res/values/themeconfig.xml
@@ -27,10 +27,10 @@
     <color name="line_one">@color/app_text_primary</color>
 
     <!-- Now playing -->
-    <color name="audio_player_current_time">@color/app_text_primary</color>
-    <color name="audio_player_total_time">@color/app_text_primary</color>
-    <color name="audio_player_line_one">@color/app_text_primary</color>
-    <color name="audio_player_line_two">@color/app_text_primary</color>
+    <color name="audio_player_current_time">#ff000000</color>
+    <color name="audio_player_total_time">#ff000000</color>
+    <color name="audio_player_line_one">@color/basic_yellow</color>
+    <color name="audio_player_line_two">#ff000000</color>
 
     <!-- Bottom action bar -->
     <color name="bottom_action_bar">@color/app_background_color_dark_highlight</color>

--- a/android/apollo/res/values/themeconfig.xml
+++ b/android/apollo/res/values/themeconfig.xml
@@ -29,8 +29,8 @@
     <!-- Now playing -->
     <color name="audio_player_current_time">#ff000000</color>
     <color name="audio_player_total_time">#ff000000</color>
-    <color name="audio_player_line_one">@color/basic_yellow</color>
-    <color name="audio_player_line_two">#ff000000</color>
+    <color name="audio_player_line_one">@color/app_text_primary</color>
+    <color name="audio_player_line_two">@color/app_text_primary</color>
 
     <!-- Bottom action bar -->
     <color name="bottom_action_bar">@color/app_background_color_dark_highlight</color>

--- a/android/apollo/res/values/themeconfig.xml
+++ b/android/apollo/res/values/themeconfig.xml
@@ -27,8 +27,8 @@
     <color name="line_one">@color/app_text_primary</color>
 
     <!-- Now playing -->
-    <color name="audio_player_current_time">#ff000000</color>
-    <color name="audio_player_total_time">#ff000000</color>
+    <color name="audio_player_current_time">@color/app_text_primary</color>
+    <color name="audio_player_total_time">@color/app_text_primary</color>
     <color name="audio_player_line_one">@color/app_text_primary</color>
     <color name="audio_player_line_two">@color/app_text_primary</color>
 

--- a/android/apollo/src/com/andrew/apollo/adapters/AlbumAdapter.java
+++ b/android/apollo/src/com/andrew/apollo/adapters/AlbumAdapter.java
@@ -95,7 +95,7 @@ public class AlbumAdapter extends ApolloFragmentAdapter<Album> implements Apollo
             if (mImageFetcher != null && Ref.alive(holder.mBackground)) {
                 if (mLayoutId == R.layout.list_item_detailed_no_background) {
                     holder.mBackground.get().setBackground(null);
-                    holder.mBackground.get().setBackgroundColor(convertView.getResources().getColor(R.color.app_background_white));
+                    holder.mBackground.get().setBackgroundColor(convertView.getResources().getColor(R.color.app_background_main));
                 } else {
                     // Asynchronously load the artist image on the background view
                     mImageFetcher.loadArtistImage(dataHolder.mLineTwo, holder.mBackground.get());

--- a/android/apollo/src/com/andrew/apollo/adapters/ArtistAdapter.java
+++ b/android/apollo/src/com/andrew/apollo/adapters/ArtistAdapter.java
@@ -83,7 +83,7 @@ public class ArtistAdapter extends ApolloFragmentAdapter<Artist> implements Apol
             if (Ref.alive(holder.mBackground)) {
                 if (mLayoutId == R.layout.list_item_detailed_no_background) {
                     holder.mBackground.get().setBackground(null);
-                    holder.mBackground.get().setBackgroundColor(convertView.getResources().getColor(R.color.app_background_white));
+                    holder.mBackground.get().setBackgroundColor(convertView.getResources().getColor(R.color.app_background_main));
                 } else {
                     // Set the background image
                     mImageFetcher.loadArtistImage(dataHolder.mLineOne, holder.mBackground.get());

--- a/android/apollo/src/com/andrew/apollo/ui/activities/AudioPlayerActivity.java
+++ b/android/apollo/src/com/andrew/apollo/ui/activities/AudioPlayerActivity.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2012 Andrew Neal
- * Copyright (c) 2012-2023, FrostWire(R)
- * Modified by Angel Leon (@gubatron), Alden Torres (aldenml)
+ * Copyright (c) 2012-2024, FrostWire(R)
+ * Modified by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,6 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.SearchView.OnQueryTextListener;
 import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat; // Added import
 import androidx.lifecycle.Lifecycle;
 import androidx.viewpager.widget.ViewPager;
 
@@ -94,6 +93,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Apollo's "now playing" interface.
  *
  * @author Andrew Neal (andrewdneal@gmail.com)
+ * @author Angel Leon (@gubatron)
+ * @author Alden Torres (aldenml)
+ * @author Marcelina Knitter (@marcelinkaaa)
  */
 public final class AudioPlayerActivity extends AbstractActivity implements
         OnSeekBarChangeListener,
@@ -609,7 +611,7 @@ public final class AudioPlayerActivity extends AbstractActivity implements
         if (mQueueSwitch != null) {
             mQueueSwitch.setImageResource(R.drawable.btn_switch_queue);
             // Apply tint color to the icon
-            mQueueSwitch.setImageTintList(ColorStateList.valueOf(getTintColor(this))); // Added tint application
+            mQueueSwitch.setImageTintList(ColorStateList.valueOf(UIUtils.getAppIconPrimaryColor(this)));
         }
         // Progress
         mProgress = findView(android.R.id.progress);
@@ -621,11 +623,6 @@ public final class AudioPlayerActivity extends AbstractActivity implements
         if (fwBannerView != null && !Offers.disabledAds()) {
             fwBannerView.setLayersVisibility(FWBannerView.Layers.FALLBACK, true);
         }
-    }
-
-    // Added method to retrieve the tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     private void initFWBannerView() {
@@ -1024,7 +1021,7 @@ public final class AudioPlayerActivity extends AbstractActivity implements
         ARTIST_AND_ALBUM_NAMES,
     }
 
-    private static void  musicServiceRequestTask(AudioPlayerActivity activity,
+    private static void musicServiceRequestTask(AudioPlayerActivity activity,
                                                 MusicServiceRequestType requestType) {
         switch (requestType) {
             case POSITION:

--- a/android/apollo/src/com/andrew/apollo/ui/activities/AudioPlayerActivity.java
+++ b/android/apollo/src/com/andrew/apollo/ui/activities/AudioPlayerActivity.java
@@ -27,6 +27,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.ColorStateList;
 import android.media.AudioManager;
 import android.media.audiofx.AudioEffect;
 import android.net.Uri;
@@ -56,6 +57,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.SearchView.OnQueryTextListener;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat; // Added import
 import androidx.lifecycle.Lifecycle;
 import androidx.viewpager.widget.ViewPager;
 
@@ -606,6 +608,8 @@ public final class AudioPlayerActivity extends AbstractActivity implements
         // Theme the queue switch icon
         if (mQueueSwitch != null) {
             mQueueSwitch.setImageResource(R.drawable.btn_switch_queue);
+            // Apply tint color to the icon
+            mQueueSwitch.setImageTintList(ColorStateList.valueOf(getTintColor(this))); // Added tint application
         }
         // Progress
         mProgress = findView(android.R.id.progress);
@@ -617,6 +621,11 @@ public final class AudioPlayerActivity extends AbstractActivity implements
         if (fwBannerView != null && !Offers.disabledAds()) {
             fwBannerView.setLayersVisibility(FWBannerView.Layers.FALLBACK, true);
         }
+    }
+
+    // Added method to retrieve the tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     private void initFWBannerView() {

--- a/android/apollo/src/com/andrew/apollo/ui/activities/ProfileActivity.java
+++ b/android/apollo/src/com/andrew/apollo/ui/activities/ProfileActivity.java
@@ -23,6 +23,9 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.provider.MediaStore;
 
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.core.content.ContextCompat;
+
 import androidx.annotation.NonNull;
 import androidx.viewpager.widget.ViewPager;
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener;

--- a/android/apollo/src/com/andrew/apollo/ui/activities/ProfileActivity.java
+++ b/android/apollo/src/com/andrew/apollo/ui/activities/ProfileActivity.java
@@ -23,9 +23,6 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.provider.MediaStore;
 
-import androidx.core.graphics.drawable.DrawableCompat;
-import androidx.core.content.ContextCompat;
-
 import androidx.annotation.NonNull;
 import androidx.viewpager.widget.ViewPager;
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener;

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/PlaylistFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/PlaylistFragment.java
@@ -1,13 +1,13 @@
 /*
  * Copyright (C) 2012 Andrew Neal
  * Modified by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2013-2017, FrostWire(R). All rights reserved.
+ * Copyright (c) 2013-2014, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,10 +18,15 @@
 
 package com.andrew.apollo.ui.fragments;
 
+import static com.andrew.apollo.loaders.PlaylistLoader.FAVORITE_PLAYLIST_ID;
+import static com.andrew.apollo.loaders.PlaylistLoader.LAST_ADDED_PLAYLIST_ID;
+import static com.andrew.apollo.loaders.PlaylistLoader.NEW_PLAYLIST_ID;
+
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
 import android.content.Loader;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import android.view.ContextMenu;
@@ -34,6 +39,9 @@ import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+
 import com.andrew.apollo.Config;
 import com.andrew.apollo.adapters.PlaylistAdapter;
 import com.andrew.apollo.loaders.PlaylistLoader;
@@ -45,19 +53,11 @@ import com.andrew.apollo.ui.fragments.profile.ApolloFragment;
 import com.andrew.apollo.utils.MusicUtils;
 import com.andrew.apollo.utils.PreferenceUtils;
 import com.frostwire.android.R;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.AbstractActivity;
 import com.frostwire.android.gui.views.AbstractDialog;
 
 import java.util.List;
-
-import static com.andrew.apollo.loaders.PlaylistLoader.FAVORITE_PLAYLIST_ID;
-import static com.andrew.apollo.loaders.PlaylistLoader.LAST_ADDED_PLAYLIST_ID;
-import static com.andrew.apollo.loaders.PlaylistLoader.NEW_PLAYLIST_ID;
-
-// Added imports for tinting
-import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
-import android.graphics.drawable.Drawable;
 
 /**
  * This class is used to display all of the playlists on a user's device.
@@ -85,7 +85,7 @@ public class PlaylistFragment extends ApolloFragment<PlaylistAdapter, Playlist> 
         mItem = mAdapter.getItem(mPosition);
 
         // Initialize the tint color
-        int tintColor = ContextCompat.getColor(getActivity(), R.color.app_icon_primary);
+        int tintColor = UIUtils.getAppIconPrimaryColor(getActivity());
 
         // Play the playlist
         MenuItem playSelectionItem = menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.PLAY_SELECTION, Menu.NONE, R.string.context_menu_play_selection);

--- a/android/apollo/src/com/andrew/apollo/ui/fragments/PlaylistFragment.java
+++ b/android/apollo/src/com/andrew/apollo/ui/fragments/PlaylistFragment.java
@@ -27,6 +27,7 @@ import android.provider.MediaStore;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.AdapterContextMenuInfo;
@@ -53,6 +54,11 @@ import static com.andrew.apollo.loaders.PlaylistLoader.FAVORITE_PLAYLIST_ID;
 import static com.andrew.apollo.loaders.PlaylistLoader.LAST_ADDED_PLAYLIST_ID;
 import static com.andrew.apollo.loaders.PlaylistLoader.NEW_PLAYLIST_ID;
 
+// Added imports for tinting
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+import android.graphics.drawable.Drawable;
+
 /**
  * This class is used to display all of the playlists on a user's device.
  *
@@ -78,19 +84,47 @@ public class PlaylistFragment extends ApolloFragment<PlaylistAdapter, Playlist> 
         menu.clear();
         mItem = mAdapter.getItem(mPosition);
 
+        // Initialize the tint color
+        int tintColor = ContextCompat.getColor(getActivity(), R.color.app_icon_primary);
+
         // Play the playlist
-        menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.PLAY_SELECTION, Menu.NONE, R.string.context_menu_play_selection)
-                .setIcon(R.drawable.contextmenu_icon_play);
+        MenuItem playSelectionItem = menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.PLAY_SELECTION, Menu.NONE, R.string.context_menu_play_selection);
+        Drawable playIcon = ContextCompat.getDrawable(getActivity(), R.drawable.contextmenu_icon_play);
+        if (playIcon != null) {
+            playIcon = DrawableCompat.wrap(playIcon);
+            DrawableCompat.setTint(playIcon, tintColor);
+            playSelectionItem.setIcon(playIcon);
+        }
 
         // Add the playlist to the queue
-        menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.ADD_TO_QUEUE, Menu.NONE, R.string.add_to_queue)
-                .setIcon(R.drawable.contextmenu_icon_queue_add);
+        MenuItem addToQueueItem = menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.ADD_TO_QUEUE, Menu.NONE, R.string.add_to_queue);
+        Drawable queueIcon = ContextCompat.getDrawable(getActivity(), R.drawable.contextmenu_icon_queue_add);
+        if (queueIcon != null) {
+            queueIcon = DrawableCompat.wrap(queueIcon);
+            DrawableCompat.setTint(queueIcon, tintColor);
+            addToQueueItem.setIcon(queueIcon);
+        }
 
         // Delete and rename (user made playlists)
         long pId = mItem.mPlaylistId;
         if (pId != NEW_PLAYLIST_ID && pId != FAVORITE_PLAYLIST_ID && pId != LAST_ADDED_PLAYLIST_ID) {
-            menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.RENAME_PLAYLIST, Menu.NONE, R.string.context_menu_rename_playlist).setIcon(R.drawable.contextmenu_icon_rename);
-            menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.DELETE, Menu.NONE, R.string.context_menu_delete).setIcon(R.drawable.contextmenu_icon_trash);
+            // Rename playlist
+            MenuItem renameItem = menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.RENAME_PLAYLIST, Menu.NONE, R.string.context_menu_rename_playlist);
+            Drawable renameIcon = ContextCompat.getDrawable(getActivity(), R.drawable.contextmenu_icon_rename);
+            if (renameIcon != null) {
+                renameIcon = DrawableCompat.wrap(renameIcon);
+                DrawableCompat.setTint(renameIcon, tintColor);
+                renameItem.setIcon(renameIcon);
+            }
+
+            // Delete playlist
+            MenuItem deleteItem = menu.add(Fragments.PLAYLIST_FRAGMENT_GROUP_ID, FragmentMenuItems.DELETE, Menu.NONE, R.string.context_menu_delete);
+            Drawable deleteIcon = ContextCompat.getDrawable(getActivity(), R.drawable.contextmenu_icon_trash);
+            if (deleteIcon != null) {
+                deleteIcon = DrawableCompat.wrap(deleteIcon);
+                DrawableCompat.setTint(deleteIcon, tintColor);
+                deleteItem.setIcon(deleteIcon);
+            }
         }
     }
 

--- a/android/apollo/src/com/andrew/apollo/utils/MusicUtils.java
+++ b/android/apollo/src/com/andrew/apollo/utils/MusicUtils.java
@@ -1688,7 +1688,7 @@ public final class MusicUtils {
                     Drawable icon = ContextCompat.getDrawable(context, R.drawable.contextmenu_icon_add_to_existing_playlist_dark);
                     if (icon != null) {
                         icon = DrawableCompat.wrap(icon);
-                        DrawableCompat.setTint(icon, ContextCompat.getColor(context, R.color.app_icon_primary));
+                        DrawableCompat.setTint(icon, UIUtils.getAppIconPrimaryColor(context));
                     }
 
                     subMenu.add(groupId, FragmentMenuItems.PLAYLIST_SELECTED, Menu.NONE, name)

--- a/android/apollo/src/com/andrew/apollo/utils/MusicUtils.java
+++ b/android/apollo/src/com/andrew/apollo/utils/MusicUtils.java
@@ -19,6 +19,8 @@
 package com.andrew.apollo.utils;
 
 import android.app.Activity;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.core.content.ContextCompat;
 import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.ContentUris;
@@ -28,6 +30,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.database.Cursor;
 import android.database.CursorIndexOutOfBoundsException;
+import android.graphics.drawable.Drawable;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
@@ -1672,6 +1675,7 @@ public final class MusicUtils {
         }
         subMenu.add(groupId, FragmentMenuItems.NEW_PLAYLIST, Menu.NONE, R.string.new_empty_playlist)
                 .setIcon(R.drawable.contextmenu_icon_playlist_add_dark);
+
         Cursor cursor = PlaylistLoader.makePlaylistCursor(context);
         if (cursor != null && cursor.getCount() > 0 && cursor.moveToFirst()) {
             while (!cursor.isAfterLast()) {
@@ -1679,8 +1683,17 @@ public final class MusicUtils {
                 String name = cursor.getString(1);
                 if (name != null) {
                     intent.putExtra("playlist", getIdForPlaylist(context, name));
-                    subMenu.add(groupId, FragmentMenuItems.PLAYLIST_SELECTED, Menu.NONE,
-                            name).setIntent(intent).setIcon(R.drawable.contextmenu_icon_add_to_existing_playlist_dark);
+
+                    // Apply tint color to the icon
+                    Drawable icon = ContextCompat.getDrawable(context, R.drawable.contextmenu_icon_add_to_existing_playlist_dark);
+                    if (icon != null) {
+                        icon = DrawableCompat.wrap(icon);
+                        DrawableCompat.setTint(icon, ContextCompat.getColor(context, R.color.app_icon_primary));
+                    }
+
+                    subMenu.add(groupId, FragmentMenuItems.PLAYLIST_SELECTED, Menu.NONE, name)
+                            .setIntent(intent)
+                            .setIcon(icon);
                 }
                 cursor.moveToNext();
             }

--- a/android/apollo/src/com/andrew/apollo/widgets/PlayPauseButton.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/PlayPauseButton.java
@@ -19,7 +19,6 @@
 package com.andrew.apollo.widgets;
 
 import android.content.Context;
-import android.content.res.ColorStateList; // Added import
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -27,7 +26,6 @@ import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
 
 import androidx.appcompat.widget.AppCompatImageButton;
-import androidx.core.content.ContextCompat; // Added import
 
 import com.andrew.apollo.utils.ApolloUtils;
 import com.andrew.apollo.utils.MusicUtils;
@@ -110,13 +108,5 @@ public final class PlayPauseButton extends AppCompatImageButton
             setContentDescription(getResources().getString(R.string.accessibility_play));
             setImageResource(playDrawable);
         }
-
-        // Apply tint color to the icon
-        setImageTintList(ColorStateList.valueOf(getTintColor(getContext())));
-    }
-
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 }

--- a/android/apollo/src/com/andrew/apollo/widgets/PlayPauseButton.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/PlayPauseButton.java
@@ -19,6 +19,7 @@
 package com.andrew.apollo.widgets;
 
 import android.content.Context;
+import android.content.res.ColorStateList; // Added import
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -26,6 +27,7 @@ import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
 
 import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.core.content.ContextCompat; // Added import
 
 import com.andrew.apollo.utils.ApolloUtils;
 import com.andrew.apollo.utils.MusicUtils;
@@ -108,5 +110,13 @@ public final class PlayPauseButton extends AppCompatImageButton
             setContentDescription(getResources().getString(R.string.accessibility_play));
             setImageResource(playDrawable);
         }
+
+        // Apply tint color to the icon
+        setImageTintList(ColorStateList.valueOf(getTintColor(getContext())));
+    }
+
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 }

--- a/android/apollo/src/com/andrew/apollo/widgets/PlayPauseButton.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/PlayPauseButton.java
@@ -19,14 +19,15 @@
 package com.andrew.apollo.widgets;
 
 import android.content.Context;
+import android.content.res.ColorStateList; // Added import
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
-import android.widget.ImageButton;
 
 import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.core.content.ContextCompat; // Added import
 
 import com.andrew.apollo.utils.ApolloUtils;
 import com.andrew.apollo.utils.MusicUtils;
@@ -34,7 +35,7 @@ import com.frostwire.android.R;
 import com.frostwire.android.util.Asyncs;
 
 /**
- * A custom {@link ImageButton} that represents the "play and pause" button.
+ * A custom {@link AppCompatImageButton} that represents the "play and pause" button.
  *
  * @author Andrew Neal (andrewdneal@gmail.com)
  */
@@ -109,5 +110,13 @@ public final class PlayPauseButton extends AppCompatImageButton
             setContentDescription(getResources().getString(R.string.accessibility_play));
             setImageResource(playDrawable);
         }
+
+        // Apply tint color to the icon
+        setImageTintList(ColorStateList.valueOf(getTintColor(getContext())));
+    }
+
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 }

--- a/android/apollo/src/com/andrew/apollo/widgets/RepeatButton.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/RepeatButton.java
@@ -20,12 +20,14 @@ package com.andrew.apollo.widgets;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.ColorStateList; // Added import
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.ImageButton;
 
 import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.core.content.ContextCompat; // Added import
 
 import com.andrew.apollo.MusicPlaybackService;
 import com.andrew.apollo.utils.MusicUtils;
@@ -72,33 +74,52 @@ public final class RepeatButton extends AppCompatImageButton
             try {
                 onClickedCallback.run();
             } catch (Throwable t) {
+                // Handle exception if necessary
             }
         }
     }
 
     /**
-     * Sets the correct drawable for the repeat state.
+     * Sets the correct drawable and tint for the repeat state.
      */
     public void updateRepeatState() {
         Asyncs.async(MusicUtils::getRepeatMode, RepeatButton::getRepeatModePost, this);
     }
 
     private void getRepeatModePost(Integer repeatMode) {
+        int iconResId;
+        int tintColor;
+
         switch (repeatMode) {
             case MusicPlaybackService.REPEAT_ALL:
                 setContentDescription(getResources().getString(R.string.accessibility_repeat_all));
-                setImageResource(R.drawable.btn_playback_repeat_all);
+                iconResId = R.drawable.btn_playback_repeat_all;
+                tintColor = getRepeatEnabledColor(getContext());
                 break;
             case MusicPlaybackService.REPEAT_CURRENT:
                 setContentDescription(getResources().getString(R.string.accessibility_repeat_one));
-                setImageResource(R.drawable.btn_playback_repeat_one);
+                iconResId = R.drawable.btn_playback_repeat_one;
+                tintColor = getRepeatEnabledColor(getContext());
                 break;
             case MusicPlaybackService.REPEAT_NONE:
                 setContentDescription(getResources().getString(R.string.accessibility_repeat));
-                setImageResource(R.drawable.btn_playback_repeat);
+                iconResId = R.drawable.btn_playback_repeat;
+                tintColor = getRepeatDisabledColor(getContext());
                 break;
             default:
-                break;
+                return;
         }
+        setImageResource(iconResId);
+        setImageTintList(ColorStateList.valueOf(tintColor));
+    }
+
+    // Method to retrieve the tint color when repeat is disabled
+    private static int getRepeatDisabledColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary); // Define in resources
+    }
+
+    // Method to retrieve the tint color when repeat is enabled
+    private static int getRepeatEnabledColor(Context context) {
+        return ContextCompat.getColor(context, R.color.basic_blue_highlight); // Define in resources
     }
 }

--- a/android/apollo/src/com/andrew/apollo/widgets/RepeatButton.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/RepeatButton.java
@@ -33,6 +33,7 @@ import com.andrew.apollo.MusicPlaybackService;
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
 import com.frostwire.android.gui.services.Engine;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.util.Asyncs;
 import com.frostwire.util.Ref;
 
@@ -115,7 +116,7 @@ public final class RepeatButton extends AppCompatImageButton
 
     // Method to retrieve the tint color when repeat is disabled
     private static int getRepeatDisabledColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary); // Define in resources
+        return UIUtils.getAppIconPrimaryColor(context);
     }
 
     // Method to retrieve the tint color when repeat is enabled

--- a/android/apollo/src/com/andrew/apollo/widgets/RepeatingImageButton.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/RepeatingImageButton.java
@@ -19,6 +19,7 @@
 package com.andrew.apollo.widgets;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.os.SystemClock;
 import android.util.AttributeSet;
 import android.view.KeyEvent;

--- a/android/apollo/src/com/andrew/apollo/widgets/ShuffleButton.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/ShuffleButton.java
@@ -29,6 +29,7 @@ import androidx.core.content.ContextCompat;
 
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.util.Asyncs;
 
 /**
@@ -91,7 +92,7 @@ public final class ShuffleButton extends AppCompatImageButton
 
     // Method to retrieve the tint color when shuffle is disabled
     private static int getShuffleDisabledTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary); // Your default tint color
+        return UIUtils.getAppIconPrimaryColor(context);
     }
 
     // Method to retrieve the color when shuffle is enabled

--- a/android/apollo/src/com/andrew/apollo/widgets/ShuffleButton.java
+++ b/android/apollo/src/com/andrew/apollo/widgets/ShuffleButton.java
@@ -18,21 +18,18 @@
 
 package com.andrew.apollo.widgets;
 
-import android.app.Activity;
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.View.OnClickListener;
 
 import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.core.content.ContextCompat;
 
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
-import com.frostwire.android.gui.services.Engine;
 import com.frostwire.android.util.Asyncs;
-import com.frostwire.util.Ref;
-
-import java.lang.ref.WeakReference;
 
 /**
  * @author Andrew Neal (andrewdneal@gmail.com)
@@ -66,19 +63,39 @@ public final class ShuffleButton extends AppCompatImageButton
             try {
                 onClickedCallback.run();
             } catch (Throwable t) {
+                // Handle exception if necessary
             }
         }
     }
 
     /**
-     * Sets the correct drawable for the shuffle state.
+     * Sets the correct drawable and tint for the shuffle state.
      */
     public void updateShuffleState() {
         Asyncs.async(MusicUtils::isShuffleEnabled, ShuffleButton::isShuffleEnabledPost, this);
     }
 
     private void isShuffleEnabledPost(Boolean shuffleEnabled) {
-        setImageResource(shuffleEnabled ? R.drawable.btn_playback_shuffle_all : R.drawable.btn_playback_shuffle);
+        int iconResId = R.drawable.btn_playback_shuffle; // Use the same icon for both states
+        setImageResource(iconResId);
+
+        if (shuffleEnabled) {
+            // When shuffle is enabled, set the tint color to blue
+            setImageTintList(ColorStateList.valueOf(getShuffleEnabledColor(getContext())));
+        } else {
+            // When shuffle is disabled, apply the default tint color
+            setImageTintList(ColorStateList.valueOf(getShuffleDisabledTintColor(getContext())));
+        }
         setContentDescription(getResources().getString(shuffleEnabled ? R.string.accessibility_shuffle_all : R.string.accessibility_shuffle));
+    }
+
+    // Method to retrieve the tint color when shuffle is disabled
+    private static int getShuffleDisabledTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary); // Your default tint color
+    }
+
+    // Method to retrieve the color when shuffle is enabled
+    private static int getShuffleEnabledColor(Context context) {
+        return ContextCompat.getColor(context, R.color.basic_blue_highlight); // The blue color you want
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -214,6 +214,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.core:core:1.10.1'
     implementation 'com.google.re2j:re2j:1.7'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.squareup.okhttp3:okhttp:5.0.0-alpha.12'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -232,6 +232,8 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:3.0.0-SNAPSHOT'
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
 
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+
     // Firebase Crashlytics
     implementation platform('com.google.firebase:firebase-bom:33.2.0')
     // When using the BoM, you don't specify versions in Firebase library dependencies

--- a/android/res/drawable-hdpi/transfer_progress_horizontal.xml
+++ b/android/res/drawable-hdpi/transfer_progress_horizontal.xml
@@ -22,7 +22,7 @@
 
     <item android:id="@android:id/background">
         <shape>
-            <solid android:color="@color/basic_gray_medium" />
+            <solid android:color="@color/basic_gray_dark" />
 
 
         </shape>

--- a/android/res/drawable/activity_buy_interstitial_ad_free_button_background.xml
+++ b/android/res/drawable/activity_buy_interstitial_ad_free_button_background.xml
@@ -22,6 +22,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/white"/>
-    <stroke android:color="@color/basic_blue_dark" android:width="4dp"/>
+    <stroke android:color="@color/basic_color_dark" android:width="4dp"/>
     <corners android:radius="5dp"/>
 </shape>

--- a/android/res/drawable/ad_menu_item_background.xml
+++ b/android/res/drawable/ad_menu_item_background.xml
@@ -21,6 +21,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/transparent"/>
-    <stroke android:color="@color/basic_white" android:width="2dp"/>
+    <stroke android:color="@color/basic_background" android:width="2dp"/>
     <corners android:radius="3dp"/>
 </shape>

--- a/android/res/drawable/blue_dark_button_background_selector_off.xml
+++ b/android/res/drawable/blue_dark_button_background_selector_off.xml
@@ -22,7 +22,7 @@
 
     <item>
         <shape>
-            <solid android:color="@color/basic_blue_dark" />
+            <solid android:color="@color/basic_color_dark" />
             <corners android:radius="4dp" />
         </shape>
     </item>

--- a/android/res/drawable/blue_dark_button_background_selector_on.xml
+++ b/android/res/drawable/blue_dark_button_background_selector_on.xml
@@ -22,7 +22,7 @@
 
     <item>
         <shape>
-            <solid android:color="@color/basic_blue" />
+            <solid android:color="@color/basic_color" />
             <corners android:radius="4dp" />
         </shape>
     </item>

--- a/android/res/drawable/clearable_edittext_background.xml
+++ b/android/res/drawable/clearable_edittext_background.xml
@@ -22,7 +22,7 @@
     android:padding="3dp"
     android:shape="rectangle">
 
-    <solid android:color="@android:color/white" />
+    <solid android:color="@color/app_search_input" />
     <corners android:radius="3dp" />
 
 </shape>

--- a/android/res/drawable/default_dialog_background.xml
+++ b/android/res/drawable/default_dialog_background.xml
@@ -21,7 +21,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle" >
 
-    <solid android:color="@color/app_background_white" />
+    <solid android:color="@color/app_background_body_dark" />
     <corners android:radius="2dp" />
 
 </shape>

--- a/android/res/drawable/default_dialog_title_background.xml
+++ b/android/res/drawable/default_dialog_title_background.xml
@@ -21,7 +21,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle" >
 
-    <solid android:color="@color/basic_blue_highlight" />
+    <solid android:color="@color/basic_blue_highlight_dark" />
     <corners android:topLeftRadius="2dp" android:topRightRadius="2dp" />
 
 </shape>

--- a/android/res/drawable/keyword_tag_close_clear_cancel_full.xml
+++ b/android/res/drawable/keyword_tag_close_clear_cancel_full.xml
@@ -42,7 +42,7 @@
             <shape android:shape="line">
                 <stroke
                     android:width="2dp"
-                    android:color="@color/basic_white" />
+                    android:color="@color/basic_background" />
             </shape>
         </rotate>
     </item>
@@ -58,7 +58,7 @@
             <shape android:shape="line">
                 <stroke
                     android:width="2dp"
-                    android:color="@color/basic_white" />
+                    android:color="@color/basic_background" />
             </shape>
         </rotate>
     </item>

--- a/android/res/drawable/keyword_tag_filter_add.xml
+++ b/android/res/drawable/keyword_tag_filter_add.xml
@@ -25,7 +25,7 @@
         android:right="0dp"
         android:top="0dp">
         <shape android:shape="oval">
-            <solid android:color="@color/basic_white" />
+            <solid android:color="@color/basic_background" />
             <stroke
                 android:width="1px"
                 android:color="@color/basic_blue_highlight_dark" />

--- a/android/res/drawable/keyword_tag_filter_add.xml
+++ b/android/res/drawable/keyword_tag_filter_add.xml
@@ -25,7 +25,7 @@
         android:right="0dp"
         android:top="0dp">
         <shape android:shape="oval">
-            <solid android:color="@color/basic_background" />
+            <solid android:color="@color/white" />
             <stroke
                 android:width="1px"
                 android:color="@color/basic_blue_highlight_dark" />

--- a/android/res/drawable/keyword_tag_filter_add.xml
+++ b/android/res/drawable/keyword_tag_filter_add.xml
@@ -25,7 +25,7 @@
         android:right="0dp"
         android:top="0dp">
         <shape android:shape="oval">
-            <solid android:color="@color/white" />
+            <solid android:color="@color/basic_background" />
             <stroke
                 android:width="1px"
                 android:color="@color/basic_blue_highlight_dark" />

--- a/android/res/drawable/keyword_tag_filter_minus.xml
+++ b/android/res/drawable/keyword_tag_filter_minus.xml
@@ -25,7 +25,7 @@
         android:right="0dp"
         android:top="0dp">
         <shape android:shape="oval">
-            <solid android:color="@color/basic_white" />
+            <solid android:color="@color/basic_background" />
             <stroke
                 android:width="1px"
                 android:color="@color/basic_blue_highlight_dark" />

--- a/android/res/drawable/keyword_tag_filter_tip_add.xml
+++ b/android/res/drawable/keyword_tag_filter_tip_add.xml
@@ -25,7 +25,7 @@
         android:right="0dp"
         android:top="0dp">
         <shape android:shape="oval">
-            <solid android:color="@color/basic_white" />
+            <solid android:color="@color/basic_background" />
             <size
                 android:width="14dp"
                 android:height="14dp" />

--- a/android/res/drawable/keyword_tag_filter_tip_minus.xml
+++ b/android/res/drawable/keyword_tag_filter_tip_minus.xml
@@ -25,7 +25,7 @@
         android:right="0dp"
         android:top="0dp">
         <shape android:shape="oval">
-            <solid android:color="@color/basic_white" />
+            <solid android:color="@color/basic_background" />
             <size
                 android:width="14dp"
                 android:height="14dp" />

--- a/android/res/drawable/listview_item_background_selector.xml
+++ b/android/res/drawable/listview_item_background_selector.xml
@@ -23,5 +23,5 @@
     <item android:drawable="@color/app_selection_background" android:state_focused="true" />
     <item android:drawable="@color/app_selection_background" android:state_selected="true" />
     <item android:drawable="@color/app_selection_background" android:state_checked="true" />
-    <item android:drawable="@color/app_background_white" />
+    <item android:drawable="@color/app_background_main" />
 </selector>

--- a/android/res/drawable/listview_item_background_selector.xml
+++ b/android/res/drawable/listview_item_background_selector.xml
@@ -23,5 +23,5 @@
     <item android:drawable="@color/app_selection_background" android:state_focused="true" />
     <item android:drawable="@color/app_selection_background" android:state_selected="true" />
     <item android:drawable="@color/app_selection_background" android:state_checked="true" />
-    <item android:drawable="@color/basic_background" />
+    <item android:drawable="@color/app_background_main" />
 </selector>

--- a/android/res/drawable/listview_item_background_selector.xml
+++ b/android/res/drawable/listview_item_background_selector.xml
@@ -23,5 +23,5 @@
     <item android:drawable="@color/app_selection_background" android:state_focused="true" />
     <item android:drawable="@color/app_selection_background" android:state_selected="true" />
     <item android:drawable="@color/app_selection_background" android:state_checked="true" />
-    <item android:drawable="@color/app_background_main" />
+    <item android:drawable="@color/basic_background" />
 </selector>

--- a/android/res/drawable/product_card_background.xml
+++ b/android/res/drawable/product_card_background.xml
@@ -30,7 +30,7 @@
           android:top="10.5dp"
           android:bottom="2dp">
         <shape android:shape="rectangle">
-            <solid android:color="@color/basic_white"/>
+            <solid android:color="@color/basic_background"/>
             <corners android:radius="3dp"/>
         </shape>
     </item>

--- a/android/res/drawable/product_card_background_selected.xml
+++ b/android/res/drawable/product_card_background_selected.xml
@@ -28,7 +28,7 @@
     <item android:left="8dp" android:top="8dp" android:right="8dp" android:bottom="8dp">
         <!-- gets painted last, on top. a smaller rectangle, filled in white with a blue stroke and rounded corners. -->
         <shape android:shape="rectangle">
-            <solid android:color="@color/basic_white"/>
+            <solid android:color="@color/basic_background"/>
             <stroke android:width="3dp" android:color="@color/basic_blue_highlight"/>
             <corners android:radius="3dp"/>
         </shape>

--- a/android/res/drawable/product_payment_options_background.xml
+++ b/android/res/drawable/product_payment_options_background.xml
@@ -21,14 +21,14 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/basic_gray_dark"/>
+            <solid android:color="@color/app_divider"/>
             <corners android:radius="3dp"/>
         </shape>
     </item>
 
     <item android:bottom="2dp">
         <shape android:shape="rectangle">
-            <solid android:color="#e2e2e2"/>
+            <solid android:color="@color/app_background_body_dark"/>
             <corners android:radius="3dp"/>
         </shape>
     </item>

--- a/android/res/drawable/tab_background_color_selector.xml
+++ b/android/res/drawable/tab_background_color_selector.xml
@@ -21,5 +21,5 @@
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/basic_blue_highlight" android:state_selected="true"/>
-    <item android:drawable="@color/app_background"/>
+    <item android:drawable="@color/app_background_color"/>
 </selector>

--- a/android/res/drawable/transfers_indicators_background.xml
+++ b/android/res/drawable/transfers_indicators_background.xml
@@ -22,7 +22,7 @@
 
     <item>
         <shape>
-            <solid android:color="@color/basic_blue_dark" />
+            <solid android:color="@color/basic_color_dark" />
         </shape>
     </item>
 

--- a/android/res/drawable/view_remove_ads_notification_background.xml
+++ b/android/res/drawable/view_remove_ads_notification_background.xml
@@ -26,7 +26,7 @@
     </item>
     <item android:top="5dp" android:left="5dp" android:right="5dp" android:bottom="5dp">
         <shape android:shape="rectangle">
-            <solid android:color="@color/basic_white" />
+            <solid android:color="@color/basic_background" />
             <corners android:radius="4dp" />
         </shape>
     </item>

--- a/android/res/layout-sw360dp-port/nav_view_header.xml
+++ b/android/res/layout-sw360dp-port/nav_view_header.xml
@@ -21,7 +21,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="132dp"
-    android:background="@color/basic_blue"
+    android:background="@color/basic_color"
     android:gravity="bottom"
     android:orientation="vertical"
     android:paddingBottom="10dp"
@@ -48,7 +48,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:text="@string/dummy_title"
-            android:textColor="@color/basic_white"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_size_small"
             android:textStyle="bold" />
 
@@ -58,7 +58,7 @@
             android:layout_height="wrap_content"
             android:layout_toEndOf="@+id/nav_view_header_main_title"
             android:text="@string/dummy_title"
-            android:textColor="@color/basic_white"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_size_small"
             android:textStyle="bold" />
 
@@ -68,7 +68,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/nav_view_header_main_title"
             android:text="@string/dummy_build"
-            android:textColor="@color/basic_gray_medium"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_size_micro" />
 
         <ImageView
@@ -84,7 +84,6 @@
             android:src="@drawable/menu_update"
             app:tint="@color/basic_green"
             android:focusable="true" />
-
 
     </RelativeLayout>
 

--- a/android/res/layout/activity_about.xml
+++ b/android/res/layout/activity_about.xml
@@ -23,7 +23,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
-              android:background="@color/app_background_main">
+              android:background="@color/app_background_body_dark">
 
     <include layout="@layout/toolbar_main"/>
 

--- a/android/res/layout/activity_about.xml
+++ b/android/res/layout/activity_about.xml
@@ -23,7 +23,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
-              android:background="@color/app_background_body_dark">
+              android:background="@color/app_background_main">
 
     <include layout="@layout/toolbar_main"/>
 

--- a/android/res/layout/activity_about.xml
+++ b/android/res/layout/activity_about.xml
@@ -23,7 +23,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
-              android:background="@color/app_background_white">
+              android:background="@color/app_background_main">
 
     <include layout="@layout/toolbar_main"/>
 

--- a/android/res/layout/activity_buy_products.xml
+++ b/android/res/layout/activity_buy_products.xml
@@ -42,7 +42,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@string/remove_ads"
-                android:textColor="@color/basic_white"
+                android:textColor="@color/basic_background"
                 android:layout_marginLeft="10dp"
                 android:layout_gravity="center_vertical" />
 

--- a/android/res/layout/activity_image_viewer.xml
+++ b/android/res/layout/activity_image_viewer.xml
@@ -22,7 +22,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/app_background_white"
+    android:background="@color/app_background_main"
     android:orientation="vertical">
 
     <include layout="@layout/toolbar_main" />

--- a/android/res/layout/activity_preview_player.xml
+++ b/android/res/layout/activity_preview_player.xml
@@ -31,7 +31,7 @@
         android:id="@+id/activity_preview_player_metadata_header"
         android:layout_width="match_parent"
         android:layout_height="@dimen/audio_player_header_height"
-        android:background="@color/app_background_white"
+        android:background="@color/app_background_main"
         android:gravity="center_vertical"
         android:orientation="vertical"
         android:paddingEnd="@dimen/audio_player_header_padding_right"

--- a/android/res/layout/activity_settings.xml
+++ b/android/res/layout/activity_settings.xml
@@ -20,7 +20,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/app_background_white"
+    android:background="@color/app_background_main"
     android:orientation="vertical">
 
     <include layout="@layout/toolbar_main" />

--- a/android/res/layout/activity_transfer_detail.xml
+++ b/android/res/layout/activity_transfer_detail.xml
@@ -22,7 +22,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/app_background_white"
+    android:background="@color/app_background_main"
     android:orientation="vertical"
     tools:context="com.frostwire.android.gui.activities.TransferDetailActivity">
 

--- a/android/res/layout/activity_wizard.xml
+++ b/android/res/layout/activity_wizard.xml
@@ -21,7 +21,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="@color/app_background_color">
 
     <com.frostwire.android.gui.views.ViewFlipper
         android:id="@+id/activity_wizard_view_flipper"

--- a/android/res/layout/confirmation_dialog_multiple_selection_list_item.xml
+++ b/android/res/layout/confirmation_dialog_multiple_selection_list_item.xml
@@ -15,10 +15,11 @@
   limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:baselineAligned="false"
-    android:orientation="horizontal" >
+    android:orientation="horizontal">
 
     <CheckBox
         android:id="@+id/view_selectable_list_item_checkbox"
@@ -31,7 +32,8 @@
         android:layout_height="35dp"
         android:layout_gravity="center|center_vertical"
         android:layout_margin="2dp"
-        android:src="@drawable/app_icon" />
+        android:src="@drawable/frostwire_notification_flat"
+        app:tint="@color/app_icon_primary" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/android/res/layout/dialog_confirm_list.xml
+++ b/android/res/layout/dialog_confirm_list.xml
@@ -118,7 +118,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_confirm_list_button_yes"
-            android:background="@color/app_background_main"
+            android:background="@drawable/default_dialog_background"
             android:text="@android:string/cancel" />
 
         <Button
@@ -127,7 +127,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@color/app_background_main"
+            android:background="@drawable/default_dialog_background"
             android:text="@android:string/ok" />
     </RelativeLayout>
 

--- a/android/res/layout/dialog_confirm_list.xml
+++ b/android/res/layout/dialog_confirm_list.xml
@@ -118,7 +118,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_confirm_list_button_yes"
-            android:background="@color/app_background_white"
+            android:background="@color/app_background_main"
             android:text="@android:string/cancel" />
 
         <Button
@@ -127,7 +127,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@color/app_background_white"
+            android:background="@color/app_background_main"
             android:text="@android:string/ok" />
     </RelativeLayout>
 

--- a/android/res/layout/dialog_confirm_list.xml
+++ b/android/res/layout/dialog_confirm_list.xml
@@ -118,7 +118,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_confirm_list_button_yes"
-            android:background="@drawable/default_dialog_background"
+            android:background="@color/app_background_main"
             android:text="@android:string/cancel" />
 
         <Button
@@ -127,7 +127,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@drawable/default_dialog_background"
+            android:background="@color/app_background_main"
             android:text="@android:string/ok" />
     </RelativeLayout>
 

--- a/android/res/layout/dialog_default.xml
+++ b/android/res/layout/dialog_default.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_button_yes"
-            android:background="@drawable/default_dialog_background"/>
+            android:background="@color/app_background_main" />
 
         <Button
                 android:id="@+id/dialog_default_button_yes"
@@ -57,6 +57,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
-                android:background="@drawable/default_dialog_background"/>
+                android:background="@color/app_background_main" />
     </RelativeLayout>
 </LinearLayout>

--- a/android/res/layout/dialog_default.xml
+++ b/android/res/layout/dialog_default.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_button_yes"
-            android:background="@color/app_background_white" />
+            android:background="@color/app_background_main" />
 
         <Button
                 android:id="@+id/dialog_default_button_yes"
@@ -57,6 +57,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
-                android:background="@color/app_background_white" />
+                android:background="@color/app_background_main" />
     </RelativeLayout>
 </LinearLayout>

--- a/android/res/layout/dialog_default.xml
+++ b/android/res/layout/dialog_default.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_button_yes"
-            android:background="@color/app_background_main" />
+            android:background="@drawable/default_dialog_background"/>
 
         <Button
                 android:id="@+id/dialog_default_button_yes"
@@ -57,6 +57,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
-                android:background="@color/app_background_main" />
+                android:background="@drawable/default_dialog_background"/>
     </RelativeLayout>
 </LinearLayout>

--- a/android/res/layout/dialog_default_checkbox.xml
+++ b/android/res/layout/dialog_default_checkbox.xml
@@ -49,7 +49,7 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp"
             android:layout_toStartOf="@+id/dialog_default_checkbox_button_yes"
-            android:background="@color/app_background_main" />
+            android:background="@drawable/default_dialog_background" />
 
         <Button
             android:id="@+id/dialog_default_checkbox_button_yes"
@@ -59,7 +59,7 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp"
             android:layout_alignParentEnd="true"
-            android:background="@color/app_background_main" />
+            android:background="@drawable/default_dialog_background" />
     </RelativeLayout>
 
     <CheckBox

--- a/android/res/layout/dialog_default_checkbox.xml
+++ b/android/res/layout/dialog_default_checkbox.xml
@@ -49,7 +49,7 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp"
             android:layout_toStartOf="@+id/dialog_default_checkbox_button_yes"
-            android:background="@color/app_background_white" />
+            android:background="@color/app_background_main" />
 
         <Button
             android:id="@+id/dialog_default_checkbox_button_yes"
@@ -59,7 +59,7 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp"
             android:layout_alignParentEnd="true"
-            android:background="@color/app_background_white" />
+            android:background="@color/app_background_main" />
     </RelativeLayout>
 
     <CheckBox

--- a/android/res/layout/dialog_default_checkbox.xml
+++ b/android/res/layout/dialog_default_checkbox.xml
@@ -49,7 +49,7 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp"
             android:layout_toStartOf="@+id/dialog_default_checkbox_button_yes"
-            android:background="@drawable/default_dialog_background" />
+            android:background="@color/app_background_main" />
 
         <Button
             android:id="@+id/dialog_default_checkbox_button_yes"
@@ -59,7 +59,7 @@
             android:paddingTop="8dp"
             android:paddingBottom="8dp"
             android:layout_alignParentEnd="true"
-            android:background="@drawable/default_dialog_background" />
+            android:background="@color/app_background_main" />
     </RelativeLayout>
 
     <CheckBox

--- a/android/res/layout/dialog_default_info.xml
+++ b/android/res/layout/dialog_default_info.xml
@@ -47,7 +47,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:background="@drawable/default_dialog_background"
+        android:background="@color/app_background_main"
         android:paddingBottom="15dp" />
 
 </LinearLayout>

--- a/android/res/layout/dialog_default_info.xml
+++ b/android/res/layout/dialog_default_info.xml
@@ -47,7 +47,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:background="@color/app_background_white"
+        android:background="@color/app_background_main"
         android:paddingBottom="15dp" />
 
 </LinearLayout>

--- a/android/res/layout/dialog_default_info.xml
+++ b/android/res/layout/dialog_default_info.xml
@@ -47,7 +47,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:background="@color/app_background_main"
+        android:background="@drawable/default_dialog_background"
         android:paddingBottom="15dp" />
 
 </LinearLayout>

--- a/android/res/layout/dialog_default_input.xml
+++ b/android/res/layout/dialog_default_input.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_input_button_yes"
-            android:background="@drawable/default_dialog_background" />
+            android:background="@color/app_background_main" />
 
         <Button
             android:id="@+id/dialog_default_input_button_yes"
@@ -57,6 +57,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@drawable/default_dialog_background" />
+            android:background="@color/app_background_main" />
     </RelativeLayout>
 </LinearLayout>

--- a/android/res/layout/dialog_default_input.xml
+++ b/android/res/layout/dialog_default_input.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_input_button_yes"
-            android:background="@color/app_background_main" />
+            android:background="@drawable/default_dialog_background" />
 
         <Button
             android:id="@+id/dialog_default_input_button_yes"
@@ -57,6 +57,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@color/app_background_main" />
+            android:background="@drawable/default_dialog_background" />
     </RelativeLayout>
 </LinearLayout>

--- a/android/res/layout/dialog_default_input.xml
+++ b/android/res/layout/dialog_default_input.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_input_button_yes"
-            android:background="@color/app_background_white" />
+            android:background="@color/app_background_main" />
 
         <Button
             android:id="@+id/dialog_default_input_button_yes"
@@ -57,6 +57,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@color/app_background_white" />
+            android:background="@color/app_background_main" />
     </RelativeLayout>
 </LinearLayout>

--- a/android/res/layout/dialog_default_update.xml
+++ b/android/res/layout/dialog_default_update.xml
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_update_button_yes"
-            android:background="@color/app_background_main" />
+            android:background="@drawable/default_dialog_background" />
 
         <Button
             android:id="@+id/dialog_default_update_button_yes"
@@ -67,6 +67,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@color/app_background_main" />
+            android:background="@drawable/default_dialog_background" />
     </RelativeLayout>
 </RelativeLayout>

--- a/android/res/layout/dialog_default_update.xml
+++ b/android/res/layout/dialog_default_update.xml
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_update_button_yes"
-            android:background="@color/app_background_white" />
+            android:background="@color/app_background_main" />
 
         <Button
             android:id="@+id/dialog_default_update_button_yes"
@@ -67,6 +67,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@color/app_background_white" />
+            android:background="@color/app_background_main" />
     </RelativeLayout>
 </RelativeLayout>

--- a/android/res/layout/dialog_default_update.xml
+++ b/android/res/layout/dialog_default_update.xml
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toStartOf="@+id/dialog_default_update_button_yes"
-            android:background="@drawable/default_dialog_background" />
+            android:background="@color/app_background_main" />
 
         <Button
             android:id="@+id/dialog_default_update_button_yes"
@@ -67,6 +67,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@drawable/default_dialog_background" />
+            android:background="@color/app_background_main" />
     </RelativeLayout>
 </RelativeLayout>

--- a/android/res/layout/dialog_file_information.xml
+++ b/android/res/layout/dialog_file_information.xml
@@ -133,7 +133,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:background="@color/app_background_white"
+        android:background="@color/app_background_main"
         android:paddingBottom="15dp"
         android:text="@string/dismiss" />
 </LinearLayout>

--- a/android/res/layout/dialog_file_information.xml
+++ b/android/res/layout/dialog_file_information.xml
@@ -133,7 +133,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:background="@drawable/default_dialog_background"
+        android:background="@color/app_background_main"
         android:paddingBottom="15dp"
         android:text="@string/dismiss" />
 </LinearLayout>

--- a/android/res/layout/dialog_file_information.xml
+++ b/android/res/layout/dialog_file_information.xml
@@ -133,7 +133,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:background="@color/app_background_main"
+        android:background="@drawable/default_dialog_background"
         android:paddingBottom="15dp"
         android:text="@string/dismiss" />
 </LinearLayout>

--- a/android/res/layout/fragment_about.xml
+++ b/android/res/layout/fragment_about.xml
@@ -19,6 +19,7 @@
  */
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true"
@@ -44,7 +45,7 @@
                 android:text="@string/dummy_title"
                 android:textSize="21sp"
                 android:textStyle="bold"
-                android:textColor="@color/app_text_primary"/>
+                android:textColor="@color/app_text_primary" />
 
             <TextView
                 android:id="@+id/fragment_about_build_number"
@@ -65,13 +66,13 @@
                 android:textSize="@dimen/text_x_medium" />
 
             <TextView
-                    android:id="@+id/fragment_about_yt_dlp_version"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:text="@string/yt_dlp_dummy_build"
-                    android:textColor="@color/app_text_secondary"
-                    android:textSize="@dimen/text_x_medium" />
+                android:id="@+id/fragment_about_yt_dlp_version"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:text="@string/yt_dlp_dummy_build"
+                android:textColor="@color/app_text_secondary"
+                android:textSize="@dimen/text_x_medium" />
 
 
             <Button
@@ -99,7 +100,8 @@
                     android:layout_height="wrap_content"
                     android:background="@color/transparent"
                     android:src="@drawable/about_social_facebook"
-                    android:contentDescription="@null"/>
+                    android:contentDescription="@null"
+                    app:tint="@color/app_icon_primary"/>
 
                 <ImageButton
                     android:id="@+id/fragment_about_twitter_button"
@@ -109,7 +111,8 @@
                     android:layout_marginEnd="10dp"
                     android:background="@color/transparent"
                     android:src="@drawable/about_social_twitter"
-                    android:contentDescription="@null"/>
+                    android:contentDescription="@null"
+                    app:tint="@color/app_icon_primary"/>
 
                 <ImageButton
                     android:id="@+id/fragment_about_reddit_button"
@@ -119,7 +122,8 @@
                     android:layout_marginEnd="20dp"
                     android:background="@color/transparent"
                     android:src="@drawable/about_social_reddit"
-                    android:contentDescription="@null"/>
+                    android:contentDescription="@null"
+                    app:tint="@color/app_icon_primary"/>
 
                 <ImageButton
                     android:id="@+id/fragment_about_github_button"
@@ -129,7 +133,8 @@
                     android:layout_marginEnd="20dp"
                     android:background="@color/transparent"
                     android:src="@drawable/about_social_github"
-                    android:contentDescription="@null"/>
+                    android:contentDescription="@null"
+                    app:tint="@color/app_icon_primary"/>
 
                 <ImageButton
                     android:id="@+id/fragment_about_slack_button"
@@ -137,7 +142,8 @@
                     android:layout_height="wrap_content"
                     android:background="@color/transparent"
                     android:src="@drawable/about_social_slack"
-                    android:contentDescription="@null"/>
+                    android:contentDescription="@null"
+                    app:tint="@color/app_icon_primary" />
 
             </LinearLayout>
 

--- a/android/res/layout/fragment_about.xml
+++ b/android/res/layout/fragment_about.xml
@@ -32,7 +32,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/app_background_body_dark"
+            android:background="@color/app_background_body_light"
             android:orientation="vertical">
 
             <TextView

--- a/android/res/layout/fragment_search.xml
+++ b/android/res/layout/fragment_search.xml
@@ -65,7 +65,7 @@
             android:id="@+id/fragment_search_framelayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/app_background_white">
+            android:background="@color/app_background_main">
 
             <com.frostwire.android.gui.views.PromotionsView
                 android:id="@+id/fragment_search_promos"

--- a/android/res/layout/fragment_transfer_detail.xml
+++ b/android/res/layout/fragment_transfer_detail.xml
@@ -22,7 +22,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/app_background_white"
+    android:background="@color/app_background_main"
     android:orientation="vertical">
 
     <com.google.android.material.tabs.TabLayout
@@ -30,7 +30,7 @@
         style="@style/AppTabLayout"
         android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:background="@color/basic_blue"
+        android:background="@color/basic_color"
         app:tabMode="scrollable" />
 
     <!--Extends androidx.viewpager.widget.ViewPager-->

--- a/android/res/layout/fragment_transfer_detail_files_recyclerview_item.xml
+++ b/android/res/layout/fragment_transfer_detail_files_recyclerview_item.xml
@@ -97,7 +97,8 @@
         android:background="@color/transparent"
         android:contentDescription="@null"
         android:scaleType="fitCenter"
-        android:src="@drawable/my_files_play_icon" />
+        android:src="@drawable/my_files_play_icon"
+        app:iconTint="@color/app_icon_primary"/>
 
     <ImageView
         android:layout_width="match_parent"

--- a/android/res/layout/fragment_transfer_detail_files_recyclerview_item.xml
+++ b/android/res/layout/fragment_transfer_detail_files_recyclerview_item.xml
@@ -19,6 +19,7 @@
  */
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -30,7 +31,8 @@
         android:layout_centerInParent="true"
         android:layout_marginEnd="5dp"
         android:contentDescription="@null"
-        android:src="@drawable/my_files_audio_icon_selector_menu" />
+        android:src="@drawable/my_files_audio_icon_selector_menu"
+        app:tint="@color/app_icon_primary" />
 
     <RelativeLayout
         android:id="@+id/fragment_transfer_detail_files_file_info_container"

--- a/android/res/layout/fragment_transfer_detail_pieces.xml
+++ b/android/res/layout/fragment_transfer_detail_pieces.xml
@@ -108,7 +108,7 @@
             android:padding="15dp"
             android:visibility="visible"
             android:background="@color/basic_gray_light"
-            app:hexhive_hexBorderColor="@color/basic_blue_dark"
+            app:hexhive_hexBorderColor="@color/basic_color_dark"
             app:hexhive_fullColor="@color/basic_blue_highlight"
             app:hexhive_emptyColor="@color/basic_gray_light"/>
 

--- a/android/res/layout/fragment_transfers.xml
+++ b/android/res/layout/fragment_transfers.xml
@@ -33,7 +33,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/basic_blue"
+        android:background="@color/basic_color"
         android:orientation="vertical">
 
         <View
@@ -68,7 +68,7 @@
         style="@style/AppTabLayout"
         android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:background="@color/basic_blue"
+        android:background="@color/basic_color"
         app:tabMode="scrollable">
 
         <com.google.android.material.tabs.TabItem
@@ -96,7 +96,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:background="@color/app_background_white">
+        android:background="@color/app_background_main">
 
         <ScrollView
             android:layout_width="match_parent"

--- a/android/res/layout/nav_view_header.xml
+++ b/android/res/layout/nav_view_header.xml
@@ -45,7 +45,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:text="@string/dummy_title"
-            android:textColor="@color/basic_white"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_size_small"
             android:textStyle="bold" />
 
@@ -55,7 +55,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/nav_view_header_main_title"
             android:text="@string/dummy_title"
-            android:textColor="@color/basic_gray_medium"
+            android:textColor="@color/app_text_secondary"
             android:textSize="@dimen/text_size_micro" />
 
         <TextView
@@ -65,7 +65,7 @@
             android:layout_below="@+id/nav_view_header_main_title"
             android:layout_toEndOf="@+id/nav_view_header_main_version"
             android:text="@string/comma"
-            android:textColor="@color/basic_gray_medium"
+            android:textColor="@color/app_text_secondary"
             android:textSize="@dimen/text_size_micro" />
 
         <TextView
@@ -76,7 +76,7 @@
             android:layout_marginStart="5dp"
             android:layout_toEndOf="@+id/nav_view_header_main_comma"
             android:text="@string/dummy_build"
-            android:textColor="@color/basic_gray_medium"
+            android:textColor="@color/app_text_secondary"
             android:textSize="@dimen/text_size_micro" />
 
         <ImageView

--- a/android/res/layout/nav_view_header.xml
+++ b/android/res/layout/nav_view_header.xml
@@ -55,7 +55,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/nav_view_header_main_title"
             android:text="@string/dummy_title"
-            android:textColor="@color/app_text_secondary"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_size_micro" />
 
         <TextView
@@ -65,7 +65,7 @@
             android:layout_below="@+id/nav_view_header_main_title"
             android:layout_toEndOf="@+id/nav_view_header_main_version"
             android:text="@string/comma"
-            android:textColor="@color/app_text_secondary"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_size_micro" />
 
         <TextView
@@ -76,7 +76,7 @@
             android:layout_marginStart="5dp"
             android:layout_toEndOf="@+id/nav_view_header_main_comma"
             android:text="@string/dummy_build"
-            android:textColor="@color/app_text_secondary"
+            android:textColor="@color/app_text_white"
             android:textSize="@dimen/text_size_micro" />
 
         <ImageView

--- a/android/res/layout/nav_view_header.xml
+++ b/android/res/layout/nav_view_header.xml
@@ -55,7 +55,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/nav_view_header_main_title"
             android:text="@string/dummy_title"
-            android:textColor="@color/app_text_white"
+            android:textColor="@color/app_text_secondary"
             android:textSize="@dimen/text_size_micro" />
 
         <TextView
@@ -65,7 +65,7 @@
             android:layout_below="@+id/nav_view_header_main_title"
             android:layout_toEndOf="@+id/nav_view_header_main_version"
             android:text="@string/comma"
-            android:textColor="@color/app_text_white"
+            android:textColor="@color/app_text_secondary"
             android:textSize="@dimen/text_size_micro" />
 
         <TextView
@@ -76,7 +76,7 @@
             android:layout_marginStart="5dp"
             android:layout_toEndOf="@+id/nav_view_header_main_comma"
             android:text="@string/dummy_build"
-            android:textColor="@color/app_text_white"
+            android:textColor="@color/app_text_secondary"
             android:textSize="@dimen/text_size_micro" />
 
         <ImageView

--- a/android/res/layout/toolbar_main.xml
+++ b/android/res/layout/toolbar_main.xml
@@ -26,7 +26,7 @@
     android:layout_height="?attr/actionBarSize"
     android:background="@color/app_toolbar_background"
     android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+    app:popupTheme="@style/Theme.AppCompat.DayNight"
     app:navigationContentDescription="@string/abc_action_bar_up_description"
     app:navigationIcon="?attr/homeAsUpIndicator"
     app:title="@string/application_label"

--- a/android/res/layout/view_ad_menuitem.xml
+++ b/android/res/layout/view_ad_menuitem.xml
@@ -59,7 +59,7 @@
         android:layout_centerVertical="true"
         android:layout_marginRight="12dp"
         android:text="@string/ad_free"
-        android:textColor="@color/basic_white"
+        android:textColor="@color/basic_background"
         android:paddingBottom="8dp"
         android:paddingTop="8dp"
         android:paddingLeft="10dp"
@@ -74,7 +74,7 @@
         android:layout_centerVertical="true"
         android:layout_marginRight="12dp"
         android:src="@drawable/ad_menu_speaker"
-        android:tint="@color/basic_white"
+        android:tint="@color/basic_background"
         android:layout_width="40dp"
         android:visibility="gone" />
 

--- a/android/res/layout/view_bittorrent_search_result_list_item.xml
+++ b/android/res/layout/view_bittorrent_search_result_list_item.xml
@@ -20,23 +20,25 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/basic_background"
     android:baselineAligned="false"
-    android:orientation="horizontal" >
+    android:orientation="horizontal">
 
     <RelativeLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
+
         <ImageView
             android:id="@+id/view_bittorrent_search_result_list_item_filetype_icon"
             android:layout_width="52dp"
             android:layout_height="match_parent"
             android:layout_gravity="center|center_vertical"
             android:layout_marginStart="3dp"
-            android:contentDescription="@null"
-            />
+            android:contentDescription="@null" />
+
         <com.frostwire.android.gui.views.MediaPlaybackStatusOverlayView
             android:id="@+id/view_bittorrent_search_result_list_item_filetype_icon_media_playback_overlay_view"
             android:layout_width="30dp"
@@ -57,7 +59,8 @@
         android:paddingRight="5dp"
         android:paddingTop="21dp"
         android:scaleType="fitCenter"
-        android:src="@drawable/download_icon" />
+        android:src="@drawable/download_icon"
+        app:tint="@color/app_icon_primary" />
 
     <RelativeLayout
         android:layout_width="0dip"

--- a/android/res/layout/view_bittorrent_search_result_list_item.xml
+++ b/android/res/layout/view_bittorrent_search_result_list_item.xml
@@ -22,7 +22,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/basic_white"
+    android:background="@color/basic_background"
     android:baselineAligned="false"
     android:orientation="horizontal" >
 

--- a/android/res/layout/view_clearable_edittext.xml
+++ b/android/res/layout/view_clearable_edittext.xml
@@ -28,8 +28,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
-        android:background="@android:color/transparent"
         android:dropDownVerticalOffset="11dp"
+        android:background="@android:color/transparent"
         android:hint="@null"
         android:imeOptions="actionSearch"
         android:inputType="text"
@@ -63,6 +63,7 @@
         android:layout_marginTop="6dp"
         android:background="@null"
         android:contentDescription="@null"
-        android:src="@drawable/clearable_edittext_clear_icon" />
+        android:src="@drawable/clearable_edittext_clear_icon"
+        android:foregroundTint="@color/basic_yellow"/>
 
 </RelativeLayout>

--- a/android/res/layout/view_frostwire_banner.xml
+++ b/android/res/layout/view_frostwire_banner.xml
@@ -18,27 +18,29 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/fw_banner_linear_layout"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:orientation="vertical"
-        android:layout_marginBottom="7dp">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fw_banner_linear_layout"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:orientation="vertical"
+    android:layout_marginBottom="7dp">
 
     <LinearLayout
-            android:gravity="center_vertical"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:orientation="horizontal">
+        android:gravity="center_vertical"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:orientation="horizontal">
 
         <ImageButton
-                android:background="@null"
-                android:layout_gravity="center_horizontal|start"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="10dp"
-                android:layout_marginTop="10dp"
-                android:layout_width="wrap_content"
-                android:src="@drawable/ad_cancel"
-                android:visibility="invisible" />
+            android:background="@null"
+            android:layout_gravity="center_horizontal|start"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
+            android:layout_marginTop="10dp"
+            android:layout_width="wrap_content"
+            android:src="@drawable/ad_cancel"
+            android:visibility="invisible"
+            app:tint="@color/app_icon_primary" />
 
         <TextView
                 android:gravity="center"
@@ -59,7 +61,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_width="wrap_content"
                 android:src="@drawable/ad_cancel"
-                android:visibility="gone" />
+                android:visibility="gone"
+                app:tint="@color/app_icon_primary"/>
     </LinearLayout>
 
     <com.applovin.mediation.ads.MaxAdView xmlns:maxads="http://schemas.applovin.com/android/1.0"

--- a/android/res/layout/view_frostwire_features_all_downloads.xml
+++ b/android/res/layout/view_frostwire_features_all_downloads.xml
@@ -32,7 +32,7 @@
         android:text="@string/all_free_downloads"
         android:background="@drawable/blue_dark_button_background_selector"
         android:textSize="@dimen/text_medium"
-        android:textColor="@color/app_text_white"
+        android:textColor="@color/basic_background"
         android:paddingTop="16dp"
         android:paddingBottom="16dp"
         android:paddingRight="24dp"

--- a/android/res/layout/view_frostwire_features_all_downloads.xml
+++ b/android/res/layout/view_frostwire_features_all_downloads.xml
@@ -32,7 +32,7 @@
         android:text="@string/all_free_downloads"
         android:background="@drawable/blue_dark_button_background_selector"
         android:textSize="@dimen/text_medium"
-        android:textColor="@color/basic_background"
+        android:textColor="@color/app_text_white"
         android:paddingTop="16dp"
         android:paddingBottom="16dp"
         android:paddingRight="24dp"

--- a/android/res/layout/view_frostwire_features_all_downloads.xml
+++ b/android/res/layout/view_frostwire_features_all_downloads.xml
@@ -32,7 +32,7 @@
         android:text="@string/all_free_downloads"
         android:background="@drawable/blue_dark_button_background_selector"
         android:textSize="@dimen/text_medium"
-        android:textColor="@color/basic_white"
+        android:textColor="@color/basic_background"
         android:paddingTop="16dp"
         android:paddingBottom="16dp"
         android:paddingRight="24dp"

--- a/android/res/layout/view_frostwire_features_title.xml
+++ b/android/res/layout/view_frostwire_features_title.xml
@@ -29,6 +29,6 @@
         android:layout_width="match_parent"
         android:padding="12dp"
         android:text="@string/frostwire_features"
-        android:textColor="@color/basic_background"
+        android:textColor="@color/app_text_white"
         android:textStyle="bold" />
 </LinearLayout>

--- a/android/res/layout/view_frostwire_features_title.xml
+++ b/android/res/layout/view_frostwire_features_title.xml
@@ -29,6 +29,6 @@
         android:layout_width="match_parent"
         android:padding="12dp"
         android:text="@string/frostwire_features"
-        android:textColor="@color/app_text_white"
+        android:textColor="@color/basic_background"
         android:textStyle="bold" />
 </LinearLayout>

--- a/android/res/layout/view_frostwire_features_title.xml
+++ b/android/res/layout/view_frostwire_features_title.xml
@@ -29,6 +29,6 @@
         android:layout_width="match_parent"
         android:padding="12dp"
         android:text="@string/frostwire_features"
-        android:textColor="@color/basic_white"
+        android:textColor="@color/basic_background"
         android:textStyle="bold" />
 </LinearLayout>

--- a/android/res/layout/view_general_wizard_page.xml
+++ b/android/res/layout/view_general_wizard_page.xml
@@ -64,7 +64,7 @@
             style="@style/WizardText.Header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/basic_blue_dark"
+            android:background="@color/basic_color_dark"
             android:paddingBottom="7dp"
             android:paddingTop="7dp"
             android:text="@string/seeding_settings" />

--- a/android/res/layout/view_header_banner.xml
+++ b/android/res/layout/view_header_banner.xml
@@ -21,7 +21,7 @@
         android:id="@+id/fragment_search_advertisement_header_layout"
         android:layout_width="match_parent"
         android:layout_height="100dp"
-        android:background="@color/app_background_dark"
+        android:background="@color/app_background_color_dark"
         android:orientation="vertical"
         android:visibility="gone">
 
@@ -86,7 +86,7 @@
         <!-- applovin banner -->
         <com.applovin.mediation.ads.MaxAdView xmlns:maxads="http://schemas.applovin.com/android/1.0"
                 android:id="@+id/view_search_header_banner_maxadview"
-                android:background="@color/basic_blue_dark"
+                android:background="@color/basic_color_dark"
                 maxads:adUnitId="95c5db83dbc84c6b"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"

--- a/android/res/layout/view_header_banner.xml
+++ b/android/res/layout/view_header_banner.xml
@@ -18,41 +18,42 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/fragment_search_advertisement_header_layout"
-        android:layout_width="match_parent"
-        android:layout_height="100dp"
-        android:background="@color/app_background_color_dark"
-        android:orientation="vertical"
-        android:visibility="gone">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fragment_search_advertisement_header_layout"
+    android:layout_width="match_parent"
+    android:layout_height="100dp"
+    android:background="@color/app_background_color_dark"
+    android:orientation="vertical"
+    android:visibility="gone">
 
     <!-- header with "advertisement" and dismiss button on top -->
     <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="5dp"
-            android:paddingTop="5dp">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="5dp"
+        android:paddingTop="5dp">
 
         <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:layout_centerVertical="true"
-                android:text="@string/advertisement"
-                android:textColor="@color/app_text_light"
-                android:textSize="@dimen/text_micro" />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:layout_centerVertical="true"
+            android:text="@string/advertisement"
+            android:textColor="@color/app_text_light"
+            android:textSize="@dimen/text_micro" />
 
         <ImageButton
-                android:id="@+id/view_search_header_banner_dismiss_banner_button"
-                android:layout_width="25dp"
-                android:layout_height="25dp"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
-                android:layout_marginEnd="14dp"
-                android:background="@null"
-                android:src="@drawable/keyword_tag_close_clear_cancel_full"
-                android:tint="@color/basic_gray_text_light"
-                android:contentDescription="@null"
-                android:visibility="invisible" />
+            android:id="@+id/view_search_header_banner_dismiss_banner_button"
+            android:layout_width="25dp"
+            android:layout_height="25dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="14dp"
+            android:background="@null"
+            android:src="@drawable/keyword_tag_close_clear_cancel_full"
+            android:contentDescription="@null"
+            android:visibility="invisible"
+            app:tint="@color/basic_gray_text_light" />
     </RelativeLayout>
     <!-- end of header -->
 

--- a/android/res/layout/view_header_banner.xml
+++ b/android/res/layout/view_header_banner.xml
@@ -18,13 +18,12 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/fragment_search_advertisement_header_layout"
-    android:layout_width="match_parent"
-    android:layout_height="100dp"
-    android:background="@color/app_background_color_dark"
-    android:orientation="vertical"
-    android:visibility="gone">
+        android:id="@+id/fragment_search_advertisement_header_layout"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:background="@color/app_background_color_dark"
+        android:orientation="vertical"
+        android:visibility="gone">
 
     <!-- header with "advertisement" and dismiss button on top -->
     <RelativeLayout

--- a/android/res/layout/view_header_banner.xml
+++ b/android/res/layout/view_header_banner.xml
@@ -18,12 +18,13 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/fragment_search_advertisement_header_layout"
-        android:layout_width="match_parent"
-        android:layout_height="100dp"
-        android:background="@color/app_background_color_dark"
-        android:orientation="vertical"
-        android:visibility="gone">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fragment_search_advertisement_header_layout"
+    android:layout_width="match_parent"
+    android:layout_height="100dp"
+    android:background="@color/app_background_color_dark"
+    android:orientation="vertical"
+    android:visibility="gone">
 
     <!-- header with "advertisement" and dismiss button on top -->
     <RelativeLayout

--- a/android/res/layout/view_permanent_status_notification.xml
+++ b/android/res/layout/view_permanent_status_notification.xml
@@ -20,7 +20,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@android:color/white"
+    android:background="@color/app_background_main"
     android:orientation="horizontal"
     android:weightSum="1.0">
 

--- a/android/res/layout/view_preference_buy_ads.xml
+++ b/android/res/layout/view_preference_buy_ads.xml
@@ -54,7 +54,7 @@
             android:paddingRight="7dp"
             android:paddingTop="2dp"
             android:text="@string/pro"
-            android:textColor="@color/basic_white"
+            android:textColor="@color/basic_background"
             android:textSize="@dimen/text_x_small"
             android:textStyle="bold" />
 

--- a/android/res/layout/view_preference_community_buttons.xml
+++ b/android/res/layout/view_preference_community_buttons.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -9,16 +10,18 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center">
+
         <Button
             android:id="@+id/view_preference_community_blog_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Blog"/>
+            android:text="Blog" />
+
         <Button
             android:id="@+id/view_preference_community_rate_our_app_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/rate_our_app"/>
+            android:text="@string/rate_our_app" />
     </LinearLayout>
 
     <LinearLayout
@@ -36,7 +39,8 @@
             android:layout_height="wrap_content"
             android:background="@color/transparent"
             android:contentDescription="@null"
-            android:src="@drawable/about_social_facebook" />
+            android:src="@drawable/about_social_facebook"
+            app:tint="@color/app_icon_primary" />
 
         <ImageButton
             android:id="@+id/view_preference_community_twitter_button"
@@ -46,7 +50,8 @@
             android:layout_marginEnd="10dp"
             android:background="@color/transparent"
             android:contentDescription="@null"
-            android:src="@drawable/about_social_twitter" />
+            android:src="@drawable/about_social_twitter"
+            app:tint="@color/app_icon_primary"/>
 
         <ImageButton
             android:id="@+id/view_preference_community_reddit_button"
@@ -56,7 +61,8 @@
             android:layout_marginEnd="20dp"
             android:background="@color/transparent"
             android:contentDescription="@null"
-            android:src="@drawable/about_social_reddit" />
+            android:src="@drawable/about_social_reddit"
+            app:tint="@color/app_icon_primary"/>
 
         <ImageButton
             android:id="@+id/view_preference_community_github_button"
@@ -66,7 +72,8 @@
             android:layout_marginEnd="20dp"
             android:background="@color/transparent"
             android:contentDescription="@null"
-            android:src="@drawable/about_social_github" />
+            android:src="@drawable/about_social_github"
+            app:tint="@color/app_icon_primary"/>
 
         <ImageButton
             android:id="@+id/view_preference_community_slack_button"
@@ -74,6 +81,7 @@
             android:layout_height="wrap_content"
             android:background="@color/transparent"
             android:contentDescription="@null"
-            android:src="@drawable/about_social_discord" />
+            android:src="@drawable/about_social_discord"
+            app:tint="@color/app_icon_primary"/>
     </LinearLayout>
 </LinearLayout>

--- a/android/res/layout/view_preference_search_select_all.xml
+++ b/android/res/layout/view_preference_search_select_all.xml
@@ -20,7 +20,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/basic_white"
+    android:background="@color/basic_background"
     android:clipToPadding="false"
     android:focusable="true"
     android:gravity="center_vertical"

--- a/android/res/layout/view_promotions.xml
+++ b/android/res/layout/view_promotions.xml
@@ -27,7 +27,7 @@
         android:id="@+id/view_promotions_gridview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@android:color/white"
+        android:background="@color/app_background_main"
         android:gravity="center"
         android:numColumns="1"
         android:stretchMode="columnWidth" />

--- a/android/res/layout/view_promotions_item.xml
+++ b/android/res/layout/view_promotions_item.xml
@@ -55,7 +55,7 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_gravity="end|center_vertical"
-            android:background="@color/app_text_primary"
+            android:background="@color/app_dark_gray"
             android:paddingLeft="15dp"
             android:paddingRight="15dp"
             android:src="@drawable/promo_read_more_button" />

--- a/android/res/layout/view_remove_ads_notification.xml
+++ b/android/res/layout/view_remove_ads_notification.xml
@@ -46,7 +46,7 @@
         android:layout_below="@+id/view_remove_ads_notification_title"
         android:layout_centerHorizontal="true"
         android:text="@string/remove_ads"
-        android:textColor="@color/basic_white"
+        android:textColor="@color/basic_background"
         android:textSize="@dimen/text_xx_large"
         android:textStyle="bold" />
 
@@ -69,7 +69,7 @@
         android:padding="14dp"
         android:text="@string/remove_ads"
         android:textAllCaps="true"
-        android:textColor="@color/basic_blue_dark"
+        android:textColor="@color/basic_color_dark"
         android:textSize="@dimen/text_small"
         android:textStyle="bold"
         android:visibility="gone" />

--- a/android/res/layout/view_rich_notification.xml
+++ b/android/res/layout/view_rich_notification.xml
@@ -99,7 +99,7 @@
             android:maxLines="1"
             android:text="@string/dummy_extra"
             android:textAppearance="@android:style/TextAppearance.Small"
-            android:textColor="@color/basic_blue"
+            android:textColor="@color/basic_color"
             android:textStyle="bold"
             android:visibility="gone" />
     </LinearLayout>

--- a/android/res/layout/view_search_header.xml
+++ b/android/res/layout/view_search_header.xml
@@ -21,7 +21,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:background="@color/app_background">
+              android:background="@color/app_background_color">
 
     <TextView
         android:id="@+id/view_search_header_text_title"
@@ -38,6 +38,6 @@
         android:layout_height="match_parent"
         android:gravity="center_vertical"
         android:text=""
-        android:textColor="@color/basic_white"
+        android:textColor="@color/basic_background"
         android:textSize="@dimen/text_small" />
 </LinearLayout>

--- a/android/res/layout/view_searchinput.xml
+++ b/android/res/layout/view_searchinput.xml
@@ -22,7 +22,7 @@
     xmlns:frostwire="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/basic_blue"
+    android:background="@color/basic_color"
     android:orientation="vertical">
 
     <View

--- a/android/res/layout/view_toolbar_title_subtitle_header.xml
+++ b/android/res/layout/view_toolbar_title_subtitle_header.xml
@@ -30,7 +30,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:text="@string/dummy_title"
-        android:textColor="@color/basic_background"
+        android:textColor="@color/app_text_primary"
         android:textSize="17dp" />
 
     <TextView
@@ -41,7 +41,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:text="@string/dummy_subtitle"
-        android:textColor="@color/basic_background"
+        android:textColor="@color/app_text_primary"
         android:textSize="@dimen/text_size_small"
         android:visibility="gone" />
 </LinearLayout>

--- a/android/res/layout/view_toolbar_title_subtitle_header.xml
+++ b/android/res/layout/view_toolbar_title_subtitle_header.xml
@@ -30,7 +30,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:text="@string/dummy_title"
-        android:textColor="@color/app_text_white"
+        android:textColor="@color/basic_background"
         android:textSize="17dp" />
 
     <TextView
@@ -41,7 +41,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:text="@string/dummy_subtitle"
-        android:textColor="@color/app_text_primary"
+        android:textColor="@color/basic_background"
         android:textSize="@dimen/text_size_small"
         android:visibility="gone" />
 </LinearLayout>

--- a/android/res/layout/view_toolbar_title_subtitle_header.xml
+++ b/android/res/layout/view_toolbar_title_subtitle_header.xml
@@ -30,7 +30,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:text="@string/dummy_title"
-        android:textColor="@color/app_text_primary"
+        android:textColor="@color/app_text_white"
         android:textSize="17dp" />
 
     <TextView

--- a/android/res/layout/view_toolbar_title_subtitle_header.xml
+++ b/android/res/layout/view_toolbar_title_subtitle_header.xml
@@ -30,7 +30,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:text="@string/dummy_title"
-        android:textColor="@color/basic_white"
+        android:textColor="@color/basic_background"
         android:textSize="17dp" />
 
     <TextView
@@ -41,7 +41,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:text="@string/dummy_subtitle"
-        android:textColor="@color/basic_white"
+        android:textColor="@color/basic_background"
         android:textSize="@dimen/text_size_small"
         android:visibility="gone" />
 </LinearLayout>

--- a/android/res/layout/view_transfer_detail_tracker_item.xml
+++ b/android/res/layout/view_transfer_detail_tracker_item.xml
@@ -19,6 +19,7 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -55,7 +56,8 @@
                 android:contentDescription="@null"
                 android:paddingEnd="2dp"
                 android:paddingStart="0dp"
-                android:src="@drawable/contextmenu_icon_rename" />
+                android:src="@drawable/contextmenu_icon_rename"
+                app:tint="@color/app_icon_primary" />
 
             <ImageView
                 android:id="@+id/view_transfer_detail_tracker_remove_button"
@@ -64,7 +66,8 @@
                 android:contentDescription="@null"
                 android:paddingEnd="5dp"
                 android:paddingStart="2dp"
-                android:src="@drawable/contextmenu_icon_remove_transfer" />
+                android:src="@drawable/contextmenu_icon_remove_transfer"
+                app:tint="@color/app_icon_primary"/>
         </LinearLayout>
 
     </LinearLayout>

--- a/android/res/layout/view_transfer_list_item.xml
+++ b/android/res/layout/view_transfer_list_item.xml
@@ -20,6 +20,7 @@
  */
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -47,7 +48,8 @@
                 android:layout_gravity="center|center_vertical"
                 android:contentDescription="@null"
                 android:scaleType="fitCenter"
-                android:src="@drawable/transfer_menuitem_plus" />
+                android:src="@drawable/transfer_menuitem_plus"
+                app:tint="@color/app_icon_primary" />
         </FrameLayout>
 
         <LinearLayout
@@ -144,7 +146,7 @@
                     android:layout_toStartOf="@+id/view_transfer_list_item_speed"
                     android:contentDescription="@null"
                     android:src="@drawable/transfers_triangle_downward"
-                    android:tint="@color/basic_gray_text_dark" />
+                    app:tint="@color/basic_gray_text_dark" />
 
                 <TextView
                     android:id="@+id/view_transfer_list_item_speed"

--- a/android/res/layout/view_transfer_list_item.xml
+++ b/android/res/layout/view_transfer_list_item.xml
@@ -168,7 +168,8 @@
             android:contentDescription="@null"
             android:scaleType="fitCenter"
             android:visibility="gone"
-            android:src="@drawable/my_files_play_icon" />
+            android:src="@drawable/my_files_play_icon"
+            app:iconTint="@color/app_icon_primary"/>
 
         <ImageButton
             android:id="@+id/view_transfer_list_item_button_details"
@@ -179,7 +180,8 @@
             android:contentDescription="@null"
             android:scaleType="fitCenter"
             android:visibility="gone"
-            android:src="@drawable/my_files_details_icon" />
+            android:src="@drawable/my_files_details_icon"
+            app:iconTint="@color/app_icon_primary"/>
 
     </LinearLayout>
     <View

--- a/android/res/layout/view_transfers_no_seeds.xml
+++ b/android/res/layout/view_transfers_no_seeds.xml
@@ -22,7 +22,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/app_background_white"
+    android:background="@color/app_background_main"
     android:clickable="true"
     android:gravity="center_vertical|center_horizontal"
     android:orientation="vertical">

--- a/android/res/layout/view_vpn_status_detail.xml
+++ b/android/res/layout/view_vpn_status_detail.xml
@@ -28,12 +28,11 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/white">
+        android:background="@color/app_background_main">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/white"
             android:orientation="vertical"
             android:padding="20dp">
 

--- a/android/res/menu/fragment_transfer_detail_menu.xml
+++ b/android/res/menu/fragment_transfer_detail_menu.xml
@@ -25,43 +25,48 @@
         android:icon="@drawable/action_bar_pause"
         android:orderInCategory="1"
         android:title="@string/transfers_context_menu_pause_stop_all_transfers"
-        app:showAsAction="always"/>
+        app:showAsAction="always"
+        app:iconTint="@color/action_bar_icon"/>
     <item
         android:id="@+id/fragment_transfer_detail_menu_clear"
         android:icon="@drawable/action_bar_stop_transfer"
         android:orderInCategory="2"
         android:title="@string/cancel_transfer"
         app:showAsAction="ifRoom"
-        />
+        app:iconTint="@color/action_bar_icon"/>
     <item
         android:id="@+id/fragment_transfer_detail_menu_delete"
         android:icon="@drawable/contextmenu_icon_trash"
         android:orderInCategory="3"
         android:title="@string/remove_torrent_and_data"
         app:showAsAction="never"
-        />
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfer_detail_menu_copy_magnet"
         android:icon="@drawable/contextmenu_icon_magnet"
         android:orderInCategory="4"
         android:title="@string/transfers_context_menu_copy_magnet"
-        app:showAsAction="never"/>
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfer_detail_menu_copy_infohash"
         android:icon="@drawable/contextmenu_icon_copy"
         android:orderInCategory="5"
         android:title="@string/transfers_context_menu_copy_infohash"
-        app:showAsAction="never"/>
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfer_detail_menu_donate_fiat"
         android:icon="@drawable/contextmenu_icon_donation_fiat"
         android:orderInCategory="6"
         android:title="@string/send_tip_donation"
-        app:showAsAction="never"/>
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfer_detail_menu_donate_bitcoin"
         android:icon="@drawable/contextmenu_icon_donation_bitcoin"
         android:orderInCategory="7"
         android:title="@string/send_bitcoin_tip"
-        app:showAsAction="never"/>
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
 </menu>

--- a/android/res/menu/fragment_transfers_menu.xml
+++ b/android/res/menu/fragment_transfers_menu.xml
@@ -26,7 +26,7 @@
         android:orderInCategory="1"
         android:title="@string/add_transfer"
         app:showAsAction="ifRoom"
-        app:iconTint="@color/app_icon_primary"/>
+        app:iconTint="@color/action_bar_icon"/>
     <item
         android:id="@+id/fragment_transfers_menu_clear_all"
         android:icon="@drawable/contextmenu_icon_stop_transfer"

--- a/android/res/menu/fragment_transfers_menu.xml
+++ b/android/res/menu/fragment_transfers_menu.xml
@@ -25,35 +25,41 @@
         android:icon="@drawable/add_transfer"
         android:orderInCategory="1"
         android:title="@string/add_transfer"
-        app:showAsAction="ifRoom"/>
+        app:showAsAction="ifRoom"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfers_menu_clear_all"
         android:icon="@drawable/contextmenu_icon_stop_transfer"
         android:orderInCategory="2"
         android:title="@string/transfers_context_menu_clear_finished"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfers_menu_pause_stop_all"
         android:icon="@drawable/contextmenu_icon_pause_transfer"
         android:orderInCategory="2"
         android:title="@string/transfers_context_menu_pause_stop_all_transfers"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfers_menu_resume_all"
         android:icon="@drawable/contextmenu_icon_play"
         android:orderInCategory="2"
         android:title="@string/transfers_context_resume_all_torrent_transfers"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfers_menu_seed_all"
         android:icon="@drawable/contextmenu_icon_seed"
         android:orderInCategory="3"
         android:title="@string/transfers_context_seed_all_transfers"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfers_menu_stop_seeding_all"
         android:icon="@drawable/contextmenu_icon_seed"
         android:orderInCategory="3"
         android:title="@string/transfers_context_stop_seeding_all_transfers"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
 </menu>

--- a/android/res/menu/fragment_transfers_menu.xml
+++ b/android/res/menu/fragment_transfers_menu.xml
@@ -26,7 +26,7 @@
         android:orderInCategory="1"
         android:title="@string/add_transfer"
         app:showAsAction="ifRoom"
-        app:iconTint="@color/action_bar_icon"/>
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/fragment_transfers_menu_clear_all"
         android:icon="@drawable/contextmenu_icon_stop_transfer"

--- a/android/res/menu/player_album_song_sort_by.xml
+++ b/android/res/menu/player_album_song_sort_by.xml
@@ -23,28 +23,34 @@
     <item
         android:icon="@drawable/contextmenu_icon_sort"
         android:title="@string/menu_sort_by"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary">
         <menu>
             <item
                 android:id="@+id/menu_player_sort_by_az"
                 android:icon="@drawable/contextmenu_icon_sort_down"
-                android:title="@string/sort_order_entry_az" />
+                android:title="@string/sort_order_entry_az"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_za"
                 android:icon="@drawable/contextmenu_icon_sort_up"
-                android:title="@string/sort_order_entry_za" />
+                android:title="@string/sort_order_entry_za"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_duration"
                 android:icon="@drawable/contextmenu_icon_time"
-                android:title="@string/sort_order_entry_duration" />
+                android:title="@string/sort_order_entry_duration"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_track_list"
                 android:icon="@drawable/contextmenu_icon_track_list"
-                android:title="@string/sort_order_entry_track_list" />
+                android:title="@string/sort_order_entry_track_list"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_filename"
                 android:icon="@drawable/contextmenu_icon_file"
-                android:title="@string/sort_order_entry_filename" />
+                android:title="@string/sort_order_entry_filename"
+                app:iconTint="@color/app_icon_primary"/>
         </menu>
     </item>
 

--- a/android/res/menu/player_album_sort_by.xml
+++ b/android/res/menu/player_album_sort_by.xml
@@ -23,28 +23,34 @@
     <item
         android:icon="@drawable/contextmenu_icon_sort"
         android:title="@string/menu_sort_by"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary">
         <menu>
             <item
                 android:id="@+id/menu_player_sort_by_az"
                 android:icon="@drawable/contextmenu_icon_sort_down"
-                android:title="@string/sort_order_entry_az" />
+                android:title="@string/sort_order_entry_az"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_za"
                 android:icon="@drawable/contextmenu_icon_sort_up"
-                android:title="@string/sort_order_entry_za" />
+                android:title="@string/sort_order_entry_za"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_year"
                 android:icon="@drawable/contextmenu_icon_year"
-                android:title="@string/sort_order_entry_year" />
+                android:title="@string/sort_order_entry_year"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_artist"
                 android:icon="@drawable/contextmenu_icon_artist"
-                android:title="@string/sort_order_entry_artist" />
+                android:title="@string/sort_order_entry_artist"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_number_of_songs"
                 android:icon="@drawable/contextmenu_icon_song"
-                android:title="@string/sort_order_entry_number_of_songs" />
+                android:title="@string/sort_order_entry_number_of_songs"
+                app:iconTint="@color/app_icon_primary"/>
         </menu>
     </item>
 

--- a/android/res/menu/player_artist_album_sort_by.xml
+++ b/android/res/menu/player_artist_album_sort_by.xml
@@ -23,24 +23,29 @@
     <item
         android:icon="@drawable/contextmenu_icon_sort"
         android:title="@string/menu_sort_by"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary">
         <menu>
             <item
                 android:id="@+id/menu_player_sort_by_az"
                 android:icon="@drawable/contextmenu_icon_sort_down"
-                android:title="@string/sort_order_entry_az" />
+                android:title="@string/sort_order_entry_az"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_za"
                 android:icon="@drawable/contextmenu_icon_sort_up"
-                android:title="@string/sort_order_entry_za" />
+                android:title="@string/sort_order_entry_za"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_year"
                 android:icon="@drawable/contextmenu_icon_year"
-                android:title="@string/sort_order_entry_year" />
+                android:title="@string/sort_order_entry_year"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_number_of_songs"
                 android:icon="@drawable/contextmenu_icon_song"
-                android:title="@string/sort_order_entry_number_of_songs" />
+                android:title="@string/sort_order_entry_number_of_songs"
+                app:iconTint="@color/app_icon_primary"/>
         </menu>
     </item>
 

--- a/android/res/menu/player_artist_song_sort_by.xml
+++ b/android/res/menu/player_artist_song_sort_by.xml
@@ -23,36 +23,44 @@
     <item
         android:icon="@drawable/contextmenu_icon_sort"
         android:title="@string/menu_sort_by"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary">
         <menu>
             <item
                 android:id="@+id/menu_player_sort_by_az"
                 android:icon="@drawable/contextmenu_icon_sort_down"
-                android:title="@string/sort_order_entry_az" />
+                android:title="@string/sort_order_entry_az"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_za"
                 android:icon="@drawable/contextmenu_icon_sort_up"
-                android:title="@string/sort_order_entry_za" />
+                android:title="@string/sort_order_entry_za"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_year"
                 android:icon="@drawable/contextmenu_icon_year"
-                android:title="@string/sort_order_entry_year" />
+                android:title="@string/sort_order_entry_year"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_album"
                 android:icon="@drawable/contextmenu_icon_album"
-                android:title="@string/sort_order_entry_album" />
+                android:title="@string/sort_order_entry_album"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_duration"
                 android:icon="@drawable/contextmenu_icon_time"
-                android:title="@string/sort_order_entry_duration" />
+                android:title="@string/sort_order_entry_duration"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_date_added"
                 android:icon="@drawable/contextmenu_icon_date"
-                android:title="@string/sort_order_entry_date_added" />
+                android:title="@string/sort_order_entry_date_added"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_filename"
                 android:icon="@drawable/contextmenu_icon_file"
-                android:title="@string/sort_order_entry_filename" />
+                android:title="@string/sort_order_entry_filename"
+                app:iconTint="@color/app_icon_primary"/>
         </menu>
     </item>
 

--- a/android/res/menu/player_artist_sort_by.xml
+++ b/android/res/menu/player_artist_sort_by.xml
@@ -23,24 +23,29 @@
     <item
         android:icon="@drawable/contextmenu_icon_sort"
         android:title="@string/menu_sort_by"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary">
         <menu>
             <item
                 android:id="@+id/menu_player_sort_by_az"
                 android:icon="@drawable/contextmenu_icon_sort_down"
-                android:title="@string/sort_order_entry_az" />
+                android:title="@string/sort_order_entry_az"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_za"
                 android:icon="@drawable/contextmenu_icon_sort_up"
-                android:title="@string/sort_order_entry_za" />
+                android:title="@string/sort_order_entry_za"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_number_of_songs"
                 android:icon="@drawable/contextmenu_icon_song"
-                android:title="@string/sort_order_entry_number_of_songs" />
+                android:title="@string/sort_order_entry_number_of_songs"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_number_of_albums"
                 android:icon="@drawable/contextmenu_icon_album"
-                android:title="@string/sort_order_entry_number_of_albums" />
+                android:title="@string/sort_order_entry_number_of_albums"
+                app:iconTint="@color/app_icon_primary"/>
         </menu>
     </item>
 

--- a/android/res/menu/player_audio_player.xml
+++ b/android/res/menu/player_audio_player.xml
@@ -24,31 +24,31 @@
         android:id="@+id/menu_player_audio_player_share"
         android:icon="@drawable/contextmenu_icon_send"
         android:title="@string/menu_share"
-        app:showAsAction="ifRoom"
-        android:iconTint="@color/app_icon_primary"/>
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_add_to_playlist"
         android:icon="@drawable/contextmenu_icon_playlist_add_dark"
         android:title="@string/add_to_playlist"
         app:showAsAction="never"
-        android:iconTint="@color/app_icon_primary"/>
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_equalizer"
         android:icon="@drawable/contextmenu_icon_equalizer"
         android:title="@string/menu_equalizer"
         app:showAsAction="never"
-        android:iconTint="@color/app_icon_primary"/>
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_stop"
         android:icon="@drawable/contextmenu_icon_stop_playback"
         android:title="@string/stop"
         app:showAsAction="never"
-        android:iconTint="@color/app_icon_primary"/>
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_delete"
         android:icon="@drawable/contextmenu_icon_trash"
         android:title="@string/context_menu_delete"
         app:showAsAction="never"
-        android:iconTint="@color/app_icon_primary"/>
+        app:iconTint="@color/app_icon_primary"/>
 
 </menu>

--- a/android/res/menu/player_audio_player.xml
+++ b/android/res/menu/player_audio_player.xml
@@ -24,26 +24,31 @@
         android:id="@+id/menu_player_audio_player_share"
         android:icon="@drawable/contextmenu_icon_send"
         android:title="@string/menu_share"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="ifRoom"
+        android:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_add_to_playlist"
         android:icon="@drawable/contextmenu_icon_playlist_add_dark"
         android:title="@string/add_to_playlist"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        android:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_equalizer"
         android:icon="@drawable/contextmenu_icon_equalizer"
         android:title="@string/menu_equalizer"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        android:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_stop"
         android:icon="@drawable/contextmenu_icon_stop_playback"
         android:title="@string/stop"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        android:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_delete"
         android:icon="@drawable/contextmenu_icon_trash"
         android:title="@string/context_menu_delete"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        android:iconTint="@color/app_icon_primary"/>
 
 </menu>

--- a/android/res/menu/player_audio_player.xml
+++ b/android/res/menu/player_audio_player.xml
@@ -24,31 +24,31 @@
         android:id="@+id/menu_player_audio_player_share"
         android:icon="@drawable/contextmenu_icon_send"
         android:title="@string/menu_share"
-        app:showAsAction="never"
-        app:iconTint="@color/app_icon_primary"/>
+        app:showAsAction="ifRoom"
+        android:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_add_to_playlist"
         android:icon="@drawable/contextmenu_icon_playlist_add_dark"
         android:title="@string/add_to_playlist"
         app:showAsAction="never"
-        app:iconTint="@color/app_icon_primary"/>
+        android:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_equalizer"
         android:icon="@drawable/contextmenu_icon_equalizer"
         android:title="@string/menu_equalizer"
         app:showAsAction="never"
-        app:iconTint="@color/app_icon_primary"/>
+        android:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_stop"
         android:icon="@drawable/contextmenu_icon_stop_playback"
         android:title="@string/stop"
         app:showAsAction="never"
-        app:iconTint="@color/app_icon_primary"/>
+        android:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_audio_player_delete"
         android:icon="@drawable/contextmenu_icon_trash"
         android:title="@string/context_menu_delete"
         app:showAsAction="never"
-        app:iconTint="@color/app_icon_primary"/>
+        android:iconTint="@color/app_icon_primary"/>
 
 </menu>

--- a/android/res/menu/player_new_playlist.xml
+++ b/android/res/menu/player_new_playlist.xml
@@ -24,6 +24,7 @@
         android:id="@+id/menu_player_new_playlist"
         android:icon="@drawable/contextmenu_icon_playlist_add_dark"
         android:title="@string/new_empty_playlist"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
 
 </menu>

--- a/android/res/menu/player_queue.xml
+++ b/android/res/menu/player_queue.xml
@@ -24,11 +24,13 @@
         android:id="@+id/menu_player_save_queue"
         android:icon="@drawable/contextmenu_icon_queue_add"
         android:title="@string/menu_save_queue"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
     <item
         android:id="@+id/menu_player_clear_queue"
         android:icon="@drawable/contextmenu_icon_queue_clear"
         android:title="@string/menu_clear_queue"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary"/>
 
 </menu>

--- a/android/res/menu/player_shuffle.xml
+++ b/android/res/menu/player_shuffle.xml
@@ -17,11 +17,13 @@
  * limitations under the License.
  */
 -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/menu_player_shuffle"
         android:icon="@drawable/contextmenu_icon_shuffle"
-        android:title="@string/menu_shuffle" />
+        android:title="@string/menu_shuffle"
+        app:iconTint="@color/app_icon_primary"/>
 
 </menu>

--- a/android/res/menu/player_song_sort_by.xml
+++ b/android/res/menu/player_song_sort_by.xml
@@ -23,36 +23,44 @@
     <item
         android:icon="@drawable/contextmenu_icon_sort"
         android:title="@string/menu_sort_by"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary">
         <menu>
             <item
                 android:id="@+id/menu_player_sort_by_az"
                 android:icon="@drawable/contextmenu_icon_sort_down"
-                android:title="@string/sort_order_entry_az" />
+                android:title="@string/sort_order_entry_az"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_za"
                 android:icon="@drawable/contextmenu_icon_sort_up"
-                android:title="@string/sort_order_entry_za" />
+                android:title="@string/sort_order_entry_za"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_year"
                 android:icon="@drawable/contextmenu_icon_year"
-                android:title="@string/sort_order_entry_year" />
+                android:title="@string/sort_order_entry_year"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_artist"
                 android:icon="@drawable/contextmenu_icon_artist"
-                android:title="@string/sort_order_entry_artist" />
+                android:title="@string/sort_order_entry_artist"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_album"
                 android:icon="@drawable/contextmenu_icon_album"
-                android:title="@string/sort_order_entry_album" />
+                android:title="@string/sort_order_entry_album"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_duration"
                 android:icon="@drawable/contextmenu_icon_time"
-                android:title="@string/sort_order_entry_duration" />
+                android:title="@string/sort_order_entry_duration"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_sort_by_filename"
                 android:icon="@drawable/contextmenu_icon_file"
-                android:title="@string/sort_order_entry_filename" />
+                android:title="@string/sort_order_entry_filename"
+                app:iconTint="@color/app_icon_primary"/>
         </menu>
     </item>
 

--- a/android/res/menu/player_view_as.xml
+++ b/android/res/menu/player_view_as.xml
@@ -23,20 +23,24 @@
     <item
         android:title="@string/menu_view_as"
         android:icon="@drawable/contextmenu_icon_view_as_detailed"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        app:iconTint="@color/app_icon_primary">
         <menu>
             <item
                 android:id="@+id/menu_player_view_as_simple"
                 android:icon="@drawable/contextmenu_icon_view_as_simple"
-                android:title="@string/menu_simple" />
+                android:title="@string/menu_simple"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_view_as_detailed"
                 android:icon="@drawable/contextmenu_icon_view_as_detailed"
-                android:title="@string/menu_detailed" />
+                android:title="@string/menu_detailed"
+                app:iconTint="@color/app_icon_primary"/>
             <item
                 android:id="@+id/menu_player_view_as_grid"
                 android:icon="@drawable/contextmenu_icon_view_as_grid"
-                android:title="@string/menu_grid" />
+                android:title="@string/menu_grid"
+                app:iconTint="@color/app_icon_primary"/>
         </menu>
     </item>
 

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -48,6 +48,7 @@
     <color name="app_divider">#2B2B2B</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_icon_primary">#B1B1B1</color>
+    <color name="action_bar_icon">#B1B1B1</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">#343434</color>

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Basic colors -->
-    <color name="basic_white">@android:color/black</color> //done
-    <color name="basic_blue">#181818</color> //done
-    <color name="basic_blue_transparent">#181818AC</color> //done
-    <color name="basic_blue_dark">#000000</color> //done
-    <color name="basic_blue_dark_highlight">@color/basic_gray_medium</color>
-    <color name="basic_blue_highlight">#2A9AC4</color>
-    <color name="basic_blue_highlight_dark">#278EB4</color> //done
-    <color name="basic_green">#0FC486</color>
-    <color name="basic_green_dark">#05a751</color>
-    <color name="basic_red">#ff0000</color>
-    <color name="basic_yellow">#ffe16a</color>
-    <color name="basic_gray_light">#101010</color> //done
-    <color name="basic_gray_medium">#2D2D2D</color> //done
-    <color name="basic_gray_dark">#A6A6A6</color> //done
-    <color name="basic_gray_text_dark">#FFFFFF</color> //done
-    <color name="basic_gray_text_medium">#E7E7E7</color> //done
-    <color name="basic_gray_text_light">#b5b5b5</color>
+    <color name="basic_background">@android:color/black</color>
+    <color name="basic_color">#1B1B1B</color>
+    <color name="basic_color_transparent">#1B1B1BAC</color>
+    <color name="basic_color_dark">#141414</color>
+    <color name="basic_color_dark_highlight">@android:color/black</color>
+    <color name="basic_blue_highlight">#33B5E5</color> //same
+    <color name="basic_blue_highlight_dark">#278EB4</color> //same
+    <color name="basic_green">#0FC486</color> //same
+    <color name="basic_green_dark">#0DAF77</color> //same
+    <color name="basic_red">#ff0000</color> //same
+    <color name="basic_yellow">#ffe16a</color> //same
+    <color name="basic_gray_light">#2B2B2B</color>
+    <color name="basic_gray_medium">#3B3B3B</color>
+    <color name="basic_gray_dark">#A6A6A6</color>
+    <color name="basic_gray_text_dark">#F2F2F2</color>
+    <color name="basic_gray_text_medium">#E0E0E0</color>
+    <color name="basic_gray_text_light">#CFCFCF</color>
 
     <!-- GENERAL APP COLORS -->
     <!-- Background Colors -->
-    <color name="app_background_white">@color/basic_white</color>
-    <color name="app_background">@color/basic_blue</color>
-    <color name="app_background_dark">@color/basic_blue_dark</color>
-    <color name="app_background_dark_highlight">@color/basic_blue_dark_highlight</color>
+    <color name="app_background_main">@color/basic_background</color>
+    <color name="app_background_color">@color/basic_color</color>
+    <color name="app_background_color_dark">@color/basic_color_dark</color>
+    <color name="app_background_color_dark_highlight">@color/basic_color_dark_highlight</color>
     <color name="app_background_body_light">@color/basic_gray_light</color>
     <color name="app_background_body_dark">@color/basic_gray_medium</color>
-    <color name="app_toolbar_background">@color/basic_blue</color>
-    <color name="app_toolbar_background_bottom">@color/basic_blue_dark_highlight</color>
+    <color name="app_toolbar_background">@color/basic_color</color>
+    <color name="app_toolbar_background_bottom">@color/basic_color_dark_highlight</color>
     <color name="app_selection_background">@color/basic_gray_light</color>
     <color name="app_rich_notification_background">@color/basic_yellow</color>
     <color name="app_browse_thumbnail_background">@color/basic_gray_medium</color>
-    <color name="app_grid_selected_background">@color/basic_blue_transparent</color>
+    <color name="app_grid_selected_background">@color/basic_color_transparent</color>
 
     <!-- Text Colors -->
     <color name="app_text_primary">@color/basic_gray_text_dark</color> //done
     <color name="app_text_secondary">@color/basic_gray_text_medium</color> //done
     <color name="app_text_disabled">@color/basic_gray_text_light</color>
-    <color name="app_text_white">#ffffff</color>
+    <color name="app_text_white">#ffffff</color> //same
     <color name="app_text_light">@color/basic_gray_text_light</color>
     <color name="app_text_highlight">@color/basic_blue_highlight_dark</color>
     <color name="app_text_wizard">#abb3bc</color>
@@ -46,7 +46,7 @@
 
     <!-- Other Colors -->
     <color name="app_divider">@color/basic_gray_medium</color>
-    <color name="app_divider_dark">@color/basic_blue_dark</color>
+    <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
 

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -30,7 +30,7 @@
     <color name="app_toolbar_background">@color/basic_color</color>
     <color name="app_toolbar_background_bottom">@color/basic_color_dark_highlight</color>
     <color name="app_selection_background">@color/basic_gray_light</color>
-    <color name="app_rich_notification_background">@color/basic_yellow</color>
+    <color name="app_rich_notification_background">#9E7F03</color>
     <color name="app_browse_thumbnail_background">@color/basic_gray_medium</color>
     <color name="app_grid_selected_background">@color/basic_color_transparent</color>
 
@@ -47,9 +47,11 @@
     <!-- Other Colors -->
     <color name="app_divider">#2B2B2B</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
+    <color name="app_icon_primary">#B1B1B1</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">#343434</color>
+    <color name="app_dark_gray">#2B2B2B</color>
 
 
     <!-- TODO: Below colors belong to no longer used player in nav drawer, remove with layouts -->

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Basic colors -->
+    <color name="basic_white">@android:color/black</color> //done
+    <color name="basic_blue">#181818</color> //done
+    <color name="basic_blue_transparent">#181818AC</color> //done
+    <color name="basic_blue_dark">#000000</color> //done
+    <color name="basic_blue_dark_highlight">@color/basic_gray_medium</color>
+    <color name="basic_blue_highlight">#2A9AC4</color>
+    <color name="basic_blue_highlight_dark">#278EB4</color> //done
+    <color name="basic_green">#0FC486</color>
+    <color name="basic_green_dark">#05a751</color>
+    <color name="basic_red">#ff0000</color>
+    <color name="basic_yellow">#ffe16a</color>
+    <color name="basic_gray_light">#101010</color> //done
+    <color name="basic_gray_medium">#2D2D2D</color> //done
+    <color name="basic_gray_dark">#A6A6A6</color> //done
+    <color name="basic_gray_text_dark">#FFFFFF</color> //done
+    <color name="basic_gray_text_medium">#E7E7E7</color> //done
+    <color name="basic_gray_text_light">#b5b5b5</color>
+
+    <!-- GENERAL APP COLORS -->
+    <!-- Background Colors -->
+    <color name="app_background_white">@color/basic_white</color>
+    <color name="app_background">@color/basic_blue</color>
+    <color name="app_background_dark">@color/basic_blue_dark</color>
+    <color name="app_background_dark_highlight">@color/basic_blue_dark_highlight</color>
+    <color name="app_background_body_light">@color/basic_gray_light</color>
+    <color name="app_background_body_dark">@color/basic_gray_medium</color>
+    <color name="app_toolbar_background">@color/basic_blue</color>
+    <color name="app_toolbar_background_bottom">@color/basic_blue_dark_highlight</color>
+    <color name="app_selection_background">@color/basic_gray_light</color>
+    <color name="app_rich_notification_background">@color/basic_yellow</color>
+    <color name="app_browse_thumbnail_background">@color/basic_gray_medium</color>
+    <color name="app_grid_selected_background">@color/basic_blue_transparent</color>
+
+    <!-- Text Colors -->
+    <color name="app_text_primary">@color/basic_gray_text_dark</color> //done
+    <color name="app_text_secondary">@color/basic_gray_text_medium</color> //done
+    <color name="app_text_disabled">@color/basic_gray_text_light</color>
+    <color name="app_text_white">#ffffff</color>
+    <color name="app_text_light">@color/basic_gray_text_light</color>
+    <color name="app_text_highlight">@color/basic_blue_highlight_dark</color>
+    <color name="app_text_wizard">#abb3bc</color>
+    <color name="app_text_wizard_dark">#ff6f7d88</color>
+
+    <!-- Other Colors -->
+    <color name="app_divider">@color/basic_gray_medium</color>
+    <color name="app_divider_dark">@color/basic_blue_dark</color>
+    <color name="app_approval_green">@color/basic_green_dark</color>
+    <color name="app_warning_red">@color/basic_red</color>
+
+    <!-- TODO: Below colors belong to no longer used player in nav drawer, remove with layouts -->
+
+    <!-- Other colors -->
+    <color name="tip_tag_blue">#5195ae</color>
+    <color name="my_files_listview_item_inactive_background">#ffeff0f1</color>
+    <color name="my_files_listview_item_inactive_foreground">@color/app_text_secondary</color>
+
+</resources>

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -6,8 +6,8 @@
     <color name="basic_color_transparent">#1B1B1BAC</color>
     <color name="basic_color_dark">#141414</color>
     <color name="basic_color_dark_highlight">@android:color/black</color>
-    <color name="basic_blue_highlight">#278EB4</color> //same
-    <color name="basic_blue_highlight_dark">#33B5E5</color> //same
+    <color name="basic_blue_highlight">#33B5E5</color> //same
+    <color name="basic_blue_highlight_dark">#278EB4</color> //same
     <color name="basic_green">#0FC486</color> //same
     <color name="basic_green_dark">#0DAF77</color> //same
     <color name="basic_red">#ff0000</color> //same
@@ -45,10 +45,8 @@
     <color name="app_text_wizard_dark">#ff6f7d88</color>
 
     <!-- Other Colors -->
-    <color name="app_divider">#2B2B2B</color>
+    <color name="app_divider">@color/basic_gray_medium</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
-    <color name="app_icon_primary">#B1B1B1</color>
-    <color name="action_bar_icon">#ffffff</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">#343434</color>

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -48,7 +48,7 @@
     <color name="app_divider">#2B2B2B</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_icon_primary">#B1B1B1</color>
-    <color name="action_bar_icon">#B1B1B1</color>
+    <color name="action_bar_icon">#ffffff</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">#343434</color>

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -6,8 +6,8 @@
     <color name="basic_color_transparent">#1B1B1BAC</color>
     <color name="basic_color_dark">#141414</color>
     <color name="basic_color_dark_highlight">@android:color/black</color>
-    <color name="basic_blue_highlight">#33B5E5</color> //same
-    <color name="basic_blue_highlight_dark">#278EB4</color> //same
+    <color name="basic_blue_highlight">#278EB4</color> //same
+    <color name="basic_blue_highlight_dark">#33B5E5</color> //same
     <color name="basic_green">#0FC486</color> //same
     <color name="basic_green_dark">#0DAF77</color> //same
     <color name="basic_red">#ff0000</color> //same
@@ -45,12 +45,11 @@
     <color name="app_text_wizard_dark">#ff6f7d88</color>
 
     <!-- Other Colors -->
-    <color name="app_divider">@color/basic_gray_medium</color>
+    <color name="app_divider">#2B2B2B</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">#343434</color>
-    <color name="app_dark_gray">#2B2B2B</color>
 
 
     <!-- TODO: Below colors belong to no longer used player in nav drawer, remove with layouts -->

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -47,9 +47,11 @@
     <!-- Other Colors -->
     <color name="app_divider">#2B2B2B</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
+    <color name="app_icon_primary">#B1B1B1</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">#343434</color>
+    <color name="app_dark_gray">#2B2B2B</color>
 
 
     <!-- TODO: Below colors belong to no longer used player in nav drawer, remove with layouts -->

--- a/android/res/values-night/colors.xml
+++ b/android/res/values-night/colors.xml
@@ -6,8 +6,8 @@
     <color name="basic_color_transparent">#1B1B1BAC</color>
     <color name="basic_color_dark">#141414</color>
     <color name="basic_color_dark_highlight">@android:color/black</color>
-    <color name="basic_blue_highlight">#33B5E5</color> //same
-    <color name="basic_blue_highlight_dark">#278EB4</color> //same
+    <color name="basic_blue_highlight">#278EB4</color> //same
+    <color name="basic_blue_highlight_dark">#33B5E5</color> //same
     <color name="basic_green">#0FC486</color> //same
     <color name="basic_green_dark">#0DAF77</color> //same
     <color name="basic_red">#ff0000</color> //same
@@ -45,10 +45,12 @@
     <color name="app_text_wizard_dark">#ff6f7d88</color>
 
     <!-- Other Colors -->
-    <color name="app_divider">@color/basic_gray_medium</color>
+    <color name="app_divider">#2B2B2B</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
+    <color name="app_search_input">#343434</color>
+
 
     <!-- TODO: Below colors belong to no longer used player in nav drawer, remove with layouts -->
 

--- a/android/res/values/arrays.xml
+++ b/android/res/values/arrays.xml
@@ -15,6 +15,16 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources>
+    <string-array name="theme_mode_labels">
+        <item>@string/light</item>
+        <item>@string/dark</item>
+        <item>@string/system</item>
+    </string-array>
 
+    <string-array name="theme_mode_entries" translatable="false">
+        <item>light</item>
+        <item>dark</item>
+        <item>system</item>
+    </string-array>
 </resources>

--- a/android/res/values/colors.xml
+++ b/android/res/values/colors.xml
@@ -66,10 +66,11 @@
     <color name="app_text_wizard_dark">#ff6f7d88</color>
 
     <!-- Other Colors -->
-    <color name="app_divider">@color/basic_gray_medium</color>
+    <color name="app_divider">#D3D3D3</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
+    <color name="app_search_input">@android:color/white</color>
 
     <!-- TODO: Below colors belong to no longer used player in nav drawer, remove with layouts -->
 

--- a/android/res/values/colors.xml
+++ b/android/res/values/colors.xml
@@ -66,12 +66,11 @@
     <color name="app_text_wizard_dark">#ff6f7d88</color>
 
     <!-- Other Colors -->
-    <color name="app_divider">@color/basic_gray_medium</color>
+    <color name="app_divider">#D3D3D3</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">@android:color/white</color>
-    <color name="app_dark_gray">#2B2B2B</color>
 
     <!-- TODO: Below colors belong to no longer used player in nav drawer, remove with layouts -->
 

--- a/android/res/values/colors.xml
+++ b/android/res/values/colors.xml
@@ -68,9 +68,11 @@
     <!-- Other Colors -->
     <color name="app_divider">#D3D3D3</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
+    <color name="app_icon_primary">#555555</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">@android:color/white</color>
+    <color name="app_dark_gray">#2B2B2B</color>
 
     <!-- TODO: Below colors belong to no longer used player in nav drawer, remove with layouts -->
 

--- a/android/res/values/colors.xml
+++ b/android/res/values/colors.xml
@@ -66,10 +66,8 @@
     <color name="app_text_wizard_dark">#ff6f7d88</color>
 
     <!-- Other Colors -->
-    <color name="app_divider">#D3D3D3</color>
+    <color name="app_divider">@color/basic_gray_medium</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
-    <color name="app_icon_primary">#555555</color>
-    <color name="action_bar_icon">#ffffff</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">@android:color/white</color>

--- a/android/res/values/colors.xml
+++ b/android/res/values/colors.xml
@@ -69,6 +69,7 @@
     <color name="app_divider">#D3D3D3</color>
     <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_icon_primary">#555555</color>
+    <color name="action_bar_icon">#ffffff</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
     <color name="app_search_input">@android:color/white</color>

--- a/android/res/values/colors.xml
+++ b/android/res/values/colors.xml
@@ -22,15 +22,15 @@
 <resources>
 
     <!-- Basic colors -->
-    <color name="basic_white">@android:color/white</color>
-    <color name="basic_blue">#38536a</color>
-    <color name="basic_blue_transparent">#642889AC</color>
-    <color name="basic_blue_dark">#264053</color>
-    <color name="basic_blue_dark_highlight">#21313f</color>
+    <color name="basic_background">@android:color/white</color>
+    <color name="basic_color">#38536a</color>
+    <color name="basic_color_transparent">#642889AC</color>
+    <color name="basic_color_dark">#264053</color>
+    <color name="basic_color_dark_highlight">#21313f</color>
     <color name="basic_blue_highlight">#33b5e5</color>
-    <color name="basic_blue_highlight_dark">#2e9ec7</color>
+    <color name="basic_blue_highlight_dark">#278EB4</color>
     <color name="basic_green">#0FC486</color>
-    <color name="basic_green_dark">#05a751</color>
+    <color name="basic_green_dark">#0DAF77</color>
     <color name="basic_red">#ff0000</color>
     <color name="basic_yellow">#ffe16a</color>
     <color name="basic_gray_light">#F2F2F2</color>
@@ -42,24 +42,24 @@
 
     <!-- GENERAL APP COLORS -->
     <!-- Background Colors -->
-    <color name="app_background_white">@color/basic_white</color>
-    <color name="app_background">@color/basic_blue</color>
-    <color name="app_background_dark">@color/basic_blue_dark</color>
-    <color name="app_background_dark_highlight">@color/basic_blue_dark_highlight</color>
+    <color name="app_background_main">@color/basic_background</color>
+    <color name="app_background_color">@color/basic_color</color>
+    <color name="app_background_color_dark">@color/basic_color_dark</color>
+    <color name="app_background_color_dark_highlight">@color/basic_color_dark_highlight</color>
     <color name="app_background_body_light">@color/basic_gray_light</color>
     <color name="app_background_body_dark">@color/basic_gray_medium</color>
-    <color name="app_toolbar_background">@color/basic_blue</color>
-    <color name="app_toolbar_background_bottom">@color/basic_blue_dark_highlight</color>
+    <color name="app_toolbar_background">@color/basic_color</color>
+    <color name="app_toolbar_background_bottom">@color/basic_color_dark_highlight</color>
     <color name="app_selection_background">@color/basic_gray_light</color>
     <color name="app_rich_notification_background">@color/basic_yellow</color>
     <color name="app_browse_thumbnail_background">@color/basic_gray_medium</color>
-    <color name="app_grid_selected_background">@color/basic_blue_transparent</color>
+    <color name="app_grid_selected_background">@color/basic_color_transparent</color>
 
     <!-- Text Colors -->
     <color name="app_text_primary">@color/basic_gray_text_dark</color>
     <color name="app_text_secondary">@color/basic_gray_text_medium</color>
     <color name="app_text_disabled">@color/basic_gray_text_light</color>
-    <color name="app_text_white">@color/basic_white</color>
+    <color name="app_text_white">@color/basic_background</color>
     <color name="app_text_light">@color/basic_gray_text_light</color>
     <color name="app_text_highlight">@color/basic_blue_highlight_dark</color>
     <color name="app_text_wizard">#abb3bc</color>
@@ -67,7 +67,7 @@
 
     <!-- Other Colors -->
     <color name="app_divider">@color/basic_gray_medium</color>
-    <color name="app_divider_dark">@color/basic_blue_dark</color>
+    <color name="app_divider_dark">@color/basic_color_dark</color>
     <color name="app_approval_green">@color/basic_green_dark</color>
     <color name="app_warning_red">@color/basic_red</color>
 

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -20,8 +20,11 @@
 -->
 <resources>
 
-    <string name="dark_mode">Dark Mode</string>
-    <string name="dark_mode_summary">Enable dark theme throughout the app.</string>
+    <!-- TODO: Translate to all languages -->
+    <string name="theme">Theme</string>
+    <string name="light">Light</string>
+    <string name="dark">Dark</string>
+    <string name="system">System</string>
 
     <!-- Important: Android is buggy with HTML, do not put HTML tags right next to text, leave a space, as it seems the text wrapping logic is considering HTML as visible text and you get premature wrapping. -->
     <string name="you_dont_need_a_vpn_to_use_frostwire_bullet_html"><![CDATA[<b>Disclosure:</b> Although recommended for your downloads, especially whenever downloading or exchanging sensitive information (e.g. banking) and while using public Wi-Fi or mobile data, <b>you don\'t need a VPN to use FrostWire. </b>]]></string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -19,6 +19,10 @@
  */
 -->
 <resources>
+
+    <string name="dark_mode">Dark Mode</string>
+    <string name="dark_mode_summary">Enable dark theme throughout the app.</string>
+
     <!-- Important: Android is buggy with HTML, do not put HTML tags right next to text, leave a space, as it seems the text wrapping logic is considering HTML as visible text and you get premature wrapping. -->
     <string name="you_dont_need_a_vpn_to_use_frostwire_bullet_html"><![CDATA[<b>Disclosure:</b> Although recommended for your downloads, especially whenever downloading or exchanging sensitive information (e.g. banking) and while using public Wi-Fi or mobile data, <b>you don\'t need a VPN to use FrostWire. </b>]]></string>
     <string name="unprotected_connections_visibility_bullet_html"><![CDATA[ <b>Your privacy is a fundamental human right</b>. An unprotected connection means everything you do online including <b>downloads, searches, messaging</b>, can be monitored and intercepted by anyone on your network, e.g. Internet Service Providers, hackers, governments.<br><br><b>We STRONGLY recommend using a VPN service</b>. <br> Here are some options that provide reliable service and work well with FrostWire:]]></string>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -50,7 +50,7 @@
         <item name="android:indeterminateDrawable">
             @drawable/progress_indeterminate_horizontal_holo
         </item>
-        <item name="android:background">@color/basic_blue</item>
+        <item name="android:background">@color/basic_color</item>
         <item name="android:minHeight">16dip</item>
         <item name="android:maxHeight">16dip</item>
     </style>
@@ -209,7 +209,7 @@
     <style name="ListItemAd">
         <item name="android:singleLine">true</item>
         <item name="android:textSize">@dimen/text_x_small</item>
-        <item name="android:textColor">@color/basic_white</item>
+        <item name="android:textColor">@color/basic_background</item>
         <item name="android:background">#ffedb802</item>
         <item name="android:padding">2sp</item>
     </style>
@@ -223,7 +223,7 @@
     <style name="SearchResultListItemSource">
         <item name="android:singleLine">true</item>
         <item name="android:textSize">14sp</item>
-        <item name="android:textColor">@color/basic_blue</item>
+        <item name="android:textColor">@color/basic_color</item>
     </style>
 
     <style name="BlueButton">
@@ -237,7 +237,7 @@
     </style>
 
     <style name="GetVPNToastNotification">
-        <item name="android:textColor">@color/basic_white</item>
+        <item name="android:textColor">@color/basic_background</item>
         <item name="android:paddingLeft">15dp</item>
         <item name="android:paddingRight">15dp</item>
         <item name="android:paddingTop">12dp</item>
@@ -286,7 +286,7 @@
     </style>
 
     <style name="BuyNoAdsCardHint">
-        <item name="android:textColor">@color/basic_white</item>
+        <item name="android:textColor">@color/basic_background</item>
         <item name="android:background">@drawable/product_card_hint_button_background</item>
         <item name="android:textSize">@dimen/text_x_small</item>
         <item name="android:textStyle">bold</item>
@@ -326,14 +326,14 @@
     </style>
 
     <style name="BuyNoAdsAdText.Remove">
-        <item name="android:textColor">@color/basic_white</item>
+        <item name="android:textColor">@color/basic_background</item>
         <item name="android:textSize">28.0sp</item>
         <item name="android:textStyle">bold</item>
     </style>
 
     <style name="BuyNoAdsAdText.AdFree">
         <item name="android:textSize">@dimen/text_x_large</item>
-        <item name="android:textColor">@color/basic_blue_dark</item>
+        <item name="android:textColor">@color/basic_color_dark</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:paddingBottom">16dp</item>
@@ -347,7 +347,7 @@
 
     <style name="WizardActivity" parent="Theme.FrostWire">
         <item name="android:textColorSecondary">@color/app_text_wizard</item>
-        <item name="android:windowBackground">@color/app_background</item>
+        <item name="android:windowBackground">@color/app_background_color</item>
     </style>
 
     <style name="WizardTitle">
@@ -388,7 +388,7 @@
     </style>
 
     <style name="WizardDivider">
-        <item name="android:background">@color/basic_blue_dark</item>
+        <item name="android:background">@color/basic_color_dark</item>
         <item name="android:height">1dp</item>
         <item name="android:layout_marginBottom">12dp</item>
         <item name="android:layout_marginTop">12dp</item>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -137,7 +137,7 @@
 
     <!-- Transfers indicator end -->
     <style name="TransfersNotificationTitle">
-        <item name="android:textColor">@color/black</item>
+        <item name="android:textColor">@color/app_text_primary</item>
         <item name="android:fontFamily">sans-serif-condensed</item>
         <item name="android:textSize">@dimen/text_medium</item>
     </style>
@@ -223,7 +223,7 @@
     <style name="SearchResultListItemSource">
         <item name="android:singleLine">true</item>
         <item name="android:textSize">14sp</item>
-        <item name="android:textColor">@color/basic_color</item>
+        <item name="android:textColor">@color/app_text_secondary</item>
     </style>
 
     <style name="BlueButton">
@@ -355,7 +355,7 @@
         <item name="android:gravity">center</item>
         <item name="android:paddingBottom">3dp</item>
         <item name="android:paddingTop">15dp</item>
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">@color/app_text_white</item>
         <item name="android:textSize">@dimen/title_text</item>
     </style>
 

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -81,7 +81,7 @@
 
     <style name="ToolbarMainHeaderTitle">
         <item name="android:textSize">@dimen/text_large</item>
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">@color/app_text_white</item>
     </style>
 
     <style name="ToolbarMainHeaderCounter">
@@ -249,6 +249,7 @@
         <item name="android:textSize">@dimen/text_size_x_large</item>
         <item name="android:fontFamily">sans-serif-regular</item>
         <item name="android:layout_marginTop">-5dp</item>
+        <item name="android:textColor">@color/app_text_primary</item>
     </style>
 
     <style name="VPNText">

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -223,7 +223,7 @@
     <style name="SearchResultListItemSource">
         <item name="android:singleLine">true</item>
         <item name="android:textSize">14sp</item>
-        <item name="android:textColor">@color/app_text_secondary</item>
+        <item name="android:textColor">@color/basic_color</item>
     </style>
 
     <style name="BlueButton">

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -223,7 +223,7 @@
     <style name="SearchResultListItemSource">
         <item name="android:singleLine">true</item>
         <item name="android:textSize">14sp</item>
-        <item name="android:textColor">@color/basic_color</item>
+        <item name="android:textColor">@color/app_text_secondary</item>
     </style>
 
     <style name="BlueButton">

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -21,7 +21,7 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="Theme.FrostWire" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Theme.FrostWire" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimary">@color/basic_blue</item>
         <item name="colorPrimaryDark">@color/basic_blue_dark</item>
         <item name="colorAccent">@color/basic_blue_highlight_dark</item>
@@ -66,7 +66,8 @@
     </style>
     
     <style name="Button" parent="ThemeOverlay.AppCompat.Dark">
+        <item name="android:textColor">@color/app_text_primary</item>
         <item name="colorButtonNormal">@color/basic_gray_dark</item>
-        <item name="colorAccent">@color/basic_gray_medium</item>
+        <item name="colorAccent">@color/basic_gray_light</item>
     </style>
 </resources>

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -3,7 +3,7 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
  * Marcelina Knitter (@marcelinkaaa)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -22,8 +22,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="Theme.FrostWire" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <item name="colorPrimary">@color/basic_blue</item>
-        <item name="colorPrimaryDark">@color/basic_blue_dark</item>
+        <item name="colorPrimary">@color/basic_color</item>
+        <item name="colorPrimaryDark">@color/basic_color_dark</item>
         <item name="colorAccent">@color/basic_blue_highlight_dark</item>
         <item name="android:textColorPrimary">@color/app_text_primary</item>
         <item name="android:textColorSecondary">@color/app_text_secondary</item>

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -45,7 +45,7 @@
     </style>
 
     <style name="ActionModeStyle.Title">
-        <item name="android:textSize">19sp</item>
+        <item name="android:textSize">60sp</item>
         <item name="android:textStyle">normal</item>
         <item name="android:textColor">@color/app_text_white</item>
     </style>

--- a/android/res/xml/settings_application.xml
+++ b/android/res/xml/settings_application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2020, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,68 +19,65 @@
 <!-- see ApplicationPreferencesFragment -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory
-        android:key="frostwire.prefs.general"
-        android:title="@string/general_settings">
+            android:key="frostwire.prefs.general"
+            android:title="@string/general_settings">
         <Preference
-            android:key="frostwire.prefs.offers.buy_no_ads"
-            android:layout="@layout/view_preference_buy_ads"
-            android:summary="@string/remove_ads_description"
-            android:title="@string/remove_ads">
+                android:key="frostwire.prefs.offers.buy_no_ads"
+                android:layout="@layout/view_preference_buy_ads"
+                android:summary="@string/remove_ads_description"
+                android:title="@string/remove_ads">
             <intent
-                android:action="android.intent.action.VIEW"
-                android:targetClass="com.frostwire.android.gui.activities.BuyActivity"
-                android:targetPackage="com.frostwire.android" />
+                    android:action="android.intent.action.VIEW"
+                    android:targetClass="com.frostwire.android.gui.activities.BuyActivity"
+                    android:targetPackage="com.frostwire.android" />
         </Preference>
         <SwitchPreference
-            android:key="frostwire.prefs.internal.connect_disconnect"
-            android:summary="@string/bittorrent_network_summary"
-            android:title="@string/bittorrent" />
+                android:key="frostwire.prefs.internal.connect_disconnect"
+                android:summary="@string/bittorrent_network_summary"
+                android:title="@string/bittorrent" />
         <SwitchPreference
-            android:key="frostwire.prefs.network.use_wifi_only"
-            android:summary="@string/wifi_networks_only_summary"
-            android:title="@string/wifi_networks_only" />
+                android:key="frostwire.prefs.network.use_wifi_only"
+                android:summary="@string/wifi_networks_only_summary"
+                android:title="@string/wifi_networks_only" />
         <SwitchPreference
-            android:key="frostwire.prefs.network.bittorrent_on_vpn_only"
-            android:summary="@string/vpn_drop_protection_summary"
-            android:title="@string/vpn_drop_protection_title" />
+                android:key="frostwire.prefs.network.bittorrent_on_vpn_only"
+                android:summary="@string/vpn_drop_protection_summary"
+                android:title="@string/vpn_drop_protection_title" />
         <SwitchPreference
-            android:key="frostwire.prefs.theme.dark_mode"
-            android:title="@string/dark_mode"
-            android:summary="@string/dark_mode_summary"
-            android:defaultValue="false" />
+                android:key="frostwire.prefs.theme.dark_mode"
+                android:title="@string/dark_mode"
+                android:summary="@string/dark_mode_summary"
+                android:defaultValue="false" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/search_torrent_settings">
         <Preference
-            android:fragment="com.frostwire.android.gui.fragments.preference.SearchEnginesPreferenceFragment"
-            android:title="@string/search_header" />
+                android:fragment="com.frostwire.android.gui.fragments.preference.SearchEnginesPreferenceFragment"
+                android:title="@string/search_header" />
         <Preference
-            android:fragment="com.frostwire.android.gui.fragments.preference.TorrentPreferenceFragment"
-            android:title="@string/torrent_preferences_header" />
+                android:fragment="com.frostwire.android.gui.fragments.preference.TorrentPreferenceFragment"
+                android:title="@string/torrent_preferences_header" />
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="frostwire.prefs.community_buttons_category"
-        android:title="@string/community">
+            android:key="frostwire.prefs.community_buttons_category"
+            android:title="@string/community">
         <com.frostwire.android.gui.views.preference.CommunityButtonsPreference
-            android:key="frostwire.prefs.community_buttons"
-            android:title="" />
+                android:key="frostwire.prefs.community_buttons"
+                android:title="" />
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="frostwire.prefs.other_settings"
-        android:title="@string/other_settings">
+            android:key="frostwire.prefs.other_settings"
+            android:title="@string/other_settings">
         <Preference
-            android:fragment="com.frostwire.android.gui.fragments.preference.OtherFragment"
-            android:title="@string/notification_other_header" />
-
-
-
+                android:fragment="com.frostwire.android.gui.fragments.preference.OtherFragment"
+                android:title="@string/notification_other_header" />
         <Preference android:title="@string/about">
             <intent
-                android:action="android.intent.action.VIEW"
-                android:targetClass="com.frostwire.android.gui.activities.AboutActivity"
-                android:targetPackage="com.frostwire.android" />
+                    android:action="android.intent.action.VIEW"
+                    android:targetClass="com.frostwire.android.gui.activities.AboutActivity"
+                    android:targetPackage="com.frostwire.android" />
         </Preference>
     </PreferenceCategory>
 </PreferenceScreen>

--- a/android/res/xml/settings_application.xml
+++ b/android/res/xml/settings_application.xml
@@ -43,6 +43,11 @@
             android:key="frostwire.prefs.network.bittorrent_on_vpn_only"
             android:summary="@string/vpn_drop_protection_summary"
             android:title="@string/vpn_drop_protection_title" />
+        <SwitchPreference
+            android:key="frostwire.prefs.theme.dark_mode"
+            android:title="@string/dark_mode"
+            android:summary="@string/dark_mode_summary"
+            android:defaultValue="false" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/search_torrent_settings">
@@ -68,6 +73,9 @@
         <Preference
             android:fragment="com.frostwire.android.gui.fragments.preference.OtherFragment"
             android:title="@string/notification_other_header" />
+
+
+
         <Preference android:title="@string/about">
             <intent
                 android:action="android.intent.action.VIEW"

--- a/android/res/xml/settings_application.xml
+++ b/android/res/xml/settings_application.xml
@@ -43,11 +43,13 @@
                 android:key="frostwire.prefs.network.bittorrent_on_vpn_only"
                 android:summary="@string/vpn_drop_protection_summary"
                 android:title="@string/vpn_drop_protection_title" />
-        <SwitchPreference
-                android:key="frostwire.prefs.theme.dark_mode"
-                android:title="@string/dark_mode"
-                android:summary="@string/dark_mode_summary"
-                android:defaultValue="false" />
+        <androidx.preference.ListPreference
+                android:key="frostwire.prefs.gui.theme_mode"
+                android:title="@string/theme"
+                android:entries="@array/theme_mode_labels"
+                android:entryValues="@array/theme_mode_entries"
+                android:defaultValue="@string/system"
+                android:summary="Enable Dark Mode"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/search_torrent_settings">

--- a/android/src/com/frostwire/android/core/ConfigurationDefaults.java
+++ b/android/src/com/frostwire/android/core/ConfigurationDefaults.java
@@ -19,6 +19,8 @@ package com.frostwire.android.core;
 
 import android.os.Environment;
 
+import androidx.appcompat.app.AppCompatDelegate;
+
 import com.andrew.apollo.MusicPlaybackService;
 import com.frostwire.android.BuildConfig;
 import com.frostwire.util.Hex;
@@ -86,6 +88,7 @@ final class ConfigurationDefaults {
                         Constants.AD_NETWORK_SHORTCODE_REMOVEADS
                 });
         defaultValues.put(Constants.PREF_KEY_GUI_DISTRACTION_FREE_SEARCH, false);
+
         defaultValues.put(Constants.PREF_KEY_ADNETWORK_ASK_FOR_LOCATION_PERMISSION, true);
         defaultValues.put(Constants.PREF_KEY_SEARCH_COUNT_DOWNLOAD_FOR_TORRENT_DEEP_SCAN, 20);
         defaultValues.put(Constants.PREF_KEY_SEARCH_COUNT_ROUNDS_FOR_TORRENT_DEEP_SCAN, 10);

--- a/android/src/com/frostwire/android/core/ConfigurationManager.java
+++ b/android/src/com/frostwire/android/core/ConfigurationManager.java
@@ -130,7 +130,13 @@ public final class ConfigurationManager {
             LOG.error("getInt(key=" + key + ", defValue=" + defValue + ") preferences == null");
             throw new IllegalStateException("getInt(key=" + key + ") failed, preferences:SharedPreferences is null");
         }
-        return preferences.getInt(key, defValue);
+
+        try {
+            return preferences.getInt(key, defValue);
+        } catch (ClassCastException e) {
+            LOG.error("getInt(key=" + key + ", defValue=" + defValue + ") failed", e);
+            return defValue;
+        }
     }
 
     public int getInt(String key) {

--- a/android/src/com/frostwire/android/core/Constants.java
+++ b/android/src/com/frostwire/android/core/Constants.java
@@ -121,6 +121,8 @@ public final class Constants {
     public static final String PREF_KEY_GUI_DISTRACTION_FREE_SEARCH = "frostwire.prefs.gui.distraction_free_search";
     public static final String PREF_KEY_ADNETWORK_ASK_FOR_LOCATION_PERMISSION = "frostwire.prefs.gui.adnetwork_ask_for_location";
 
+    public static final String PREF_KEY_GUI_THEME_MODE = "frostwire.prefs.gui.theme_mode";
+
     public static final String PREF_KEY_TORRENT_MAX_DOWNLOAD_SPEED = "frostwire.prefs.torrent.max_download_speed";
     public static final String PREF_KEY_TORRENT_MAX_UPLOAD_SPEED = "frostwire.prefs.torrent.max_upload_speed";
     public static final String PREF_KEY_TORRENT_MAX_DOWNLOADS = "frostwire.prefs.torrent.max_downloads";

--- a/android/src/com/frostwire/android/gui/ThemeManager.java
+++ b/android/src/com/frostwire/android/gui/ThemeManager.java
@@ -1,0 +1,118 @@
+/*
+ * Created by Angel Leon (@gubatron)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.frostwire.android.gui;
+
+import androidx.appcompat.app.AppCompatDelegate;
+
+import com.frostwire.android.core.ConfigurationManager;
+import com.frostwire.android.core.Constants;
+import com.frostwire.android.util.SystemUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Encapsulate the logic to manage the theme of the application.
+ * Created by gubatron on 6/7/14.
+ */
+public class ThemeManager {
+    private static Map<String, Integer> theme_entry_to_int_mode_map;
+
+    private static final Object theme_entry_to_int_mode_map_lock = new Object();
+    private static Map<Integer, String> theme_int_mode_to_entry_map;
+
+    private static final Object theme_int_mode_to_entry_map_lock = new Object();
+
+    public interface OnThemeLoadedUIThreadCallback {
+        void onThemeLoaded(int themeMode);
+    }
+
+    /**
+     * If called from an UI thread, this method will automatically call itself on a background handler
+     * and post the result to the UI thread on the given uiThreadCallback.
+     *
+     * @param uiThreadCallback
+     */
+    public static void loadSavedThemeModeAsync(OnThemeLoadedUIThreadCallback uiThreadCallback) {
+        if (SystemUtils.isUIThread()) {
+            SystemUtils.postToHandler(SystemUtils.HandlerThreadName.MISC, () -> loadSavedThemeModeAsync(uiThreadCallback));
+            return;
+        }
+
+        SystemUtils.ensureBackgroundThreadOrCrash("ThemeManager::loadSavedThemeModeAsync");
+        String themeEntry = ConfigurationManager.instance().getString(Constants.PREF_KEY_GUI_THEME_MODE, "system");
+        final int themeMode = getThemeModeFromEntry(themeEntry);
+        SystemUtils.postToUIThreadAtFront(() -> uiThreadCallback.onThemeLoaded(themeMode));
+    }
+
+    public static void applyThemeMode(int themeMode) {
+        AppCompatDelegate.setDefaultNightMode(themeMode);
+    }
+
+    public static void applyThemeMode(String themeEntry) {
+        int themeMode = getThemeModeFromEntry(themeEntry);
+        applyThemeMode(themeMode);
+    }
+
+    public static void saveThemeModeAsync(String themeEntry) {
+        if (SystemUtils.isUIThread()) {
+            SystemUtils.postToHandler(SystemUtils.HandlerThreadName.MISC, () -> saveThemeModeAsync(themeEntry));
+            return;
+        }
+        SystemUtils.ensureBackgroundThreadOrCrash("ThemeManager::saveThemeModeAsync");
+        ConfigurationManager.instance().setString(Constants.PREF_KEY_GUI_THEME_MODE, themeEntry.toLowerCase());
+    }
+
+    // Get the theme mode from the theme entry
+    public static int getThemeModeFromEntry(String themeEntry) {
+        initThemeEntryToIntModeMap();
+        return theme_entry_to_int_mode_map.get(themeEntry.toLowerCase());
+    }
+
+    // Get the theme entry from the theme mode
+    public static String getThemeEntryFromMode(int themeMode) {
+        initThemeModeToEntryMap();
+        return theme_int_mode_to_entry_map.get(themeMode);
+    }
+
+    // thread safe lazy initialization of the theme_entry_to_int_mode_map
+    private static void initThemeEntryToIntModeMap() {
+        if (theme_entry_to_int_mode_map != null) {
+            return;
+        }
+        synchronized (theme_entry_to_int_mode_map_lock) {
+            theme_entry_to_int_mode_map = new HashMap<>();
+            theme_entry_to_int_mode_map.put("light", AppCompatDelegate.MODE_NIGHT_NO);
+            theme_entry_to_int_mode_map.put("dark", AppCompatDelegate.MODE_NIGHT_YES);
+            theme_entry_to_int_mode_map.put("system", AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
+        }
+    }
+
+    // thread safe lazy initialization of the theme_mode_to_entry_map
+    private static void initThemeModeToEntryMap() {
+        if (theme_int_mode_to_entry_map != null) {
+            return;
+        }
+        synchronized (theme_int_mode_to_entry_map_lock) {
+            theme_int_mode_to_entry_map = new HashMap<>();
+            theme_int_mode_to_entry_map.put(AppCompatDelegate.MODE_NIGHT_NO, "light");
+            theme_int_mode_to_entry_map.put(AppCompatDelegate.MODE_NIGHT_YES, "dark");
+            theme_int_mode_to_entry_map.put(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, "system");
+        }
+    }
+}

--- a/android/src/com/frostwire/android/gui/activities/MainActivity.java
+++ b/android/src/com/frostwire/android/gui/activities/MainActivity.java
@@ -42,6 +42,7 @@ import android.view.MenuItem;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
@@ -55,6 +56,7 @@ import com.frostwire.android.core.TellurideCourier;
 import com.frostwire.android.gui.NetworkManager;
 import com.frostwire.android.gui.SearchMediator;
 import com.frostwire.android.gui.SoftwareUpdater;
+import com.frostwire.android.gui.ThemeManager;
 import com.frostwire.android.gui.activities.internal.MainController;
 import com.frostwire.android.gui.activities.internal.NavigationMenu;
 import com.frostwire.android.gui.dialogs.HandpickedTorrentDownloadDialogOnFetch;
@@ -351,6 +353,7 @@ public class MainActivity extends AbstractActivity implements
         localBroadcastReceiver.register(this);
         setupDrawer();
         ConfigurationManager CM = ConfigurationManager.instance();
+        ThemeManager.loadSavedThemeModeAsync(themeMode -> ThemeManager.applyThemeMode(themeMode));
         if (CM.getBoolean(Constants.PREF_KEY_GUI_INITIAL_SETTINGS_COMPLETE)) {
             mainResume();
             Offers.initAdNetworks(this);

--- a/android/src/com/frostwire/android/gui/adapters/menu/AbstractDeleteFilesMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/AbstractDeleteFilesMenuAction.java
@@ -26,9 +26,8 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
-import androidx.core.content.ContextCompat;
-
 import com.frostwire.android.R;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.AbstractDialog;
 import com.frostwire.android.gui.views.MenuAction;
 
@@ -43,13 +42,8 @@ public abstract class AbstractDeleteFilesMenuAction extends MenuAction {
     private final AbstractDialog.OnDialogClickListener onDialogClickListener;
 
     AbstractDeleteFilesMenuAction(final Context context, final int imageId, final int textId, AbstractDialog.OnDialogClickListener onDialogClickListener) {
-        super(context, imageId, textId, getTintColor(context));
+        super(context, imageId, textId, UIUtils.getAppIconPrimaryColor(context));
         this.onDialogClickListener = onDialogClickListener;
-    }
-
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     protected abstract void onDeleteClicked();

--- a/android/src/com/frostwire/android/gui/adapters/menu/AbstractDeleteFilesMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/AbstractDeleteFilesMenuAction.java
@@ -26,6 +26,8 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
+
 import com.frostwire.android.R;
 import com.frostwire.android.gui.views.AbstractDialog;
 import com.frostwire.android.gui.views.MenuAction;
@@ -41,11 +43,16 @@ public abstract class AbstractDeleteFilesMenuAction extends MenuAction {
     private final AbstractDialog.OnDialogClickListener onDialogClickListener;
 
     AbstractDeleteFilesMenuAction(final Context context, final int imageId, final int textId, AbstractDialog.OnDialogClickListener onDialogClickListener) {
-        super(context, imageId, textId);
+        super(context, imageId, textId, getTintColor(context));
         this.onDialogClickListener = onDialogClickListener;
     }
 
-    abstract protected void onDeleteClicked();
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
+    }
+
+    protected abstract void onDeleteClicked();
 
     @Override
     public void onClick(Context context) {
@@ -57,7 +64,8 @@ public abstract class AbstractDeleteFilesMenuAction extends MenuAction {
     }
 
     private void showDeleteFilesDialog() {
-        DeleteFileMenuActionDialog.newInstance(this, onDialogClickListener).show(((Activity) getContext()).getFragmentManager());
+        DeleteFileMenuActionDialog.newInstance(this, onDialogClickListener)
+                .show(((Activity) getContext()).getFragmentManager());
     }
 
     @SuppressWarnings("WeakerAccess")

--- a/android/src/com/frostwire/android/gui/adapters/menu/AddToPlaylistMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/AddToPlaylistMenuAction.java
@@ -19,6 +19,8 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.andrew.apollo.model.Playlist;
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
@@ -45,13 +47,18 @@ public final class AddToPlaylistMenuAction extends MenuAction {
     private long[] fds;
 
     public AddToPlaylistMenuAction(Context context, List<FWFileDescriptor> fds) {
-        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.add_to_playlist);
+        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.add_to_playlist, getTintColor(context)); // Updated super() call
         setFileIdList(fds);
     }
 
     public AddToPlaylistMenuAction(Context context, long[] fds) {
-        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.add_to_playlist);
+        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.add_to_playlist, getTintColor(context)); // Updated super() call
         this.fds = fds;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/AddToPlaylistMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/AddToPlaylistMenuAction.java
@@ -1,6 +1,6 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2022, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,11 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
-import androidx.core.content.ContextCompat; // Added import
-
 import com.andrew.apollo.model.Playlist;
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
 import com.frostwire.android.core.FWFileDescriptor;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
 import com.frostwire.android.gui.views.MenuAdapter;
 import com.frostwire.android.gui.views.MenuBuilder;
@@ -41,24 +40,20 @@ import java.util.List;
  *
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public final class AddToPlaylistMenuAction extends MenuAction {
 
     private long[] fds;
 
     public AddToPlaylistMenuAction(Context context, List<FWFileDescriptor> fds) {
-        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.add_to_playlist, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.add_to_playlist, UIUtils.getAppIconPrimaryColor(context));
         setFileIdList(fds);
     }
 
     public AddToPlaylistMenuAction(Context context, long[] fds) {
-        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.add_to_playlist, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.add_to_playlist, UIUtils.getAppIconPrimaryColor(context));
         this.fds = fds;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/AddToThisPlaylistMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/AddToThisPlaylistMenuAction.java
@@ -1,29 +1,27 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2014, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
-import androidx.core.content.ContextCompat;
-
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
 
 /**
@@ -44,14 +42,9 @@ public final class AddToThisPlaylistMenuAction extends MenuAction {
         super(context,
                 R.drawable.contextmenu_icon_add_to_existing_playlist_dark,
                 playlistName,
-                getTintColor(context));
+                UIUtils.getAppIconPrimaryColor(context));
         this.playlistId = playlistId;
         this.fileDescriptors = fileDescriptors;
-    }
-
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/AddToThisPlaylistMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/AddToThisPlaylistMenuAction.java
@@ -20,6 +20,8 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
+import androidx.core.content.ContextCompat;
+
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
 import com.frostwire.android.gui.views.MenuAction;
@@ -39,9 +41,17 @@ public final class AddToThisPlaylistMenuAction extends MenuAction {
     private final long[] fileDescriptors;
 
     public AddToThisPlaylistMenuAction(Context context, long playlistId, String playlistName, long[] fileDescriptors) {
-        super(context, R.drawable.contextmenu_icon_add_to_existing_playlist_dark, playlistName);
+        super(context,
+                R.drawable.contextmenu_icon_add_to_existing_playlist_dark,
+                playlistName,
+                getTintColor(context));
         this.playlistId = playlistId;
         this.fileDescriptors = fileDescriptors;
+    }
+
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/CancelMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/CancelMenuAction.java
@@ -1,6 +1,6 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2022, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import android.widget.TextView;
 import com.frostwire.android.R;
 import com.frostwire.android.gui.activities.MainActivity;
 import com.frostwire.android.gui.transfers.UIBittorrentDownload;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.AbstractDialog;
 import com.frostwire.android.gui.views.MenuAction;
 import com.frostwire.android.gui.views.TimerObserver;
@@ -38,11 +39,10 @@ import com.frostwire.transfers.HttpDownload;
 import com.frostwire.transfers.Transfer;
 import com.frostwire.util.Ref;
 
-import androidx.core.content.ContextCompat;
-
 /**
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public final class CancelMenuAction extends MenuAction {
 
@@ -54,7 +54,7 @@ public final class CancelMenuAction extends MenuAction {
         super(context,
                 deleteData ? R.drawable.contextmenu_icon_trash : R.drawable.contextmenu_icon_stop_transfer,
                 deleteData ? R.string.cancel_delete_menu_action : (transfer.isComplete()) ? R.string.clear_complete : R.string.cancel_menu_action,
-                getTintColor(context));
+                UIUtils.getAppIconPrimaryColor(context));
         this.transfer = transfer;
         this.deleteData = deleteData;
         this.deleteTorrent = deleteData;
@@ -64,15 +64,10 @@ public final class CancelMenuAction extends MenuAction {
         super(context,
                 deleteData ? R.drawable.contextmenu_icon_trash : R.drawable.contextmenu_icon_stop_transfer,
                 R.string.remove_torrent_and_data,
-                getTintColor(context));
+                UIUtils.getAppIconPrimaryColor(context));
         this.transfer = transfer;
         this.deleteTorrent = deleteTorrent;
         this.deleteData = deleteData;
-    }
-
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/CancelMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/CancelMenuAction.java
@@ -38,6 +38,8 @@ import com.frostwire.transfers.HttpDownload;
 import com.frostwire.transfers.Transfer;
 import com.frostwire.util.Ref;
 
+import androidx.core.content.ContextCompat;
+
 /**
  * @author gubatron
  * @author aldenml
@@ -48,11 +50,11 @@ public final class CancelMenuAction extends MenuAction {
     private final boolean deleteData;
     private final boolean deleteTorrent;
 
-
     public CancelMenuAction(Context context, Transfer transfer, boolean deleteData) {
         super(context,
                 deleteData ? R.drawable.contextmenu_icon_trash : R.drawable.contextmenu_icon_stop_transfer,
-                deleteData ? R.string.cancel_delete_menu_action : (transfer.isComplete()) ? R.string.clear_complete : R.string.cancel_menu_action);
+                deleteData ? R.string.cancel_delete_menu_action : (transfer.isComplete()) ? R.string.clear_complete : R.string.cancel_menu_action,
+                getTintColor(context));
         this.transfer = transfer;
         this.deleteData = deleteData;
         this.deleteTorrent = deleteData;
@@ -61,17 +63,23 @@ public final class CancelMenuAction extends MenuAction {
     public CancelMenuAction(Context context, BittorrentDownload transfer, boolean deleteTorrent, boolean deleteData) {
         super(context,
                 deleteData ? R.drawable.contextmenu_icon_trash : R.drawable.contextmenu_icon_stop_transfer,
-                R.string.remove_torrent_and_data);
+                R.string.remove_torrent_and_data,
+                getTintColor(context));
         this.transfer = transfer;
         this.deleteTorrent = deleteTorrent;
         this.deleteData = deleteData;
     }
 
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
+    }
+
     @Override
     public void onClick(final Context context) {
         CancelMenuActionDialog.newInstance(
-                transfer,
-                deleteData, deleteTorrent, this).
+                        transfer,
+                        deleteData, deleteTorrent, this).
                 show(((Activity) getContext()).getFragmentManager());
     }
 

--- a/android/src/com/frostwire/android/gui/adapters/menu/CopyMagnetMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/CopyMagnetMenuAction.java
@@ -1,12 +1,12 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,6 +27,7 @@ import java.io.File;
 /**
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public final class CopyMagnetMenuAction extends CopyToClipboardMenuAction {
 

--- a/android/src/com/frostwire/android/gui/adapters/menu/CopyToClipboardMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/CopyToClipboardMenuAction.java
@@ -1,13 +1,13 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
- *            Jose Molina (@votaguz)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *            Jose Molina (@votaguz), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,9 +22,6 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 
-import androidx.core.content.ContextCompat;
-
-import com.frostwire.android.R;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
 import com.frostwire.android.gui.views.TimerObserver;
@@ -34,6 +31,7 @@ import com.frostwire.util.Logger;
  * @author gubatron
  * @author aldenml
  * @author votaguz
+ * @author marcelinkaaa
  */
 public class CopyToClipboardMenuAction extends MenuAction {
 
@@ -44,14 +42,9 @@ public class CopyToClipboardMenuAction extends MenuAction {
 
     public CopyToClipboardMenuAction(Context context, int drawable, int actionNameId,
                                      int messageId, Object data) {
-        super(context, drawable, actionNameId, getTintColor(context));
+        super(context, drawable, actionNameId, UIUtils.getAppIconPrimaryColor(context));
         this.messageId = messageId;
         this.data = data;
-    }
-
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/CopyToClipboardMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/CopyToClipboardMenuAction.java
@@ -22,6 +22,9 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 
+import androidx.core.content.ContextCompat;
+
+import com.frostwire.android.R;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
 import com.frostwire.android.gui.views.TimerObserver;
@@ -41,9 +44,14 @@ public class CopyToClipboardMenuAction extends MenuAction {
 
     public CopyToClipboardMenuAction(Context context, int drawable, int actionNameId,
                                      int messageId, Object data) {
-        super(context, drawable, actionNameId);
+        super(context, drawable, actionNameId, getTintColor(context));
         this.messageId = messageId;
         this.data = data;
+    }
+
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/CreateNewPlaylistMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/CreateNewPlaylistMenuAction.java
@@ -1,12 +1,12 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,11 +26,10 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import androidx.core.content.ContextCompat; // Added import
-
 import com.andrew.apollo.ui.fragments.PlaylistFragment;
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.AbstractActivity;
 import com.frostwire.android.gui.views.AbstractDialog;
 import com.frostwire.android.gui.views.MenuAction;
@@ -42,19 +41,15 @@ import com.frostwire.android.gui.views.MenuAction;
  *
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public class CreateNewPlaylistMenuAction extends MenuAction {
 
     private final long[] fileDescriptors;
 
     public CreateNewPlaylistMenuAction(Context context, long[] fileDescriptors) {
-        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.new_empty_playlist, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.new_empty_playlist, UIUtils.getAppIconPrimaryColor(context));
         this.fileDescriptors = fileDescriptors;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/CreateNewPlaylistMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/CreateNewPlaylistMenuAction.java
@@ -26,6 +26,8 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.andrew.apollo.ui.fragments.PlaylistFragment;
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
@@ -46,8 +48,13 @@ public class CreateNewPlaylistMenuAction extends MenuAction {
     private final long[] fileDescriptors;
 
     public CreateNewPlaylistMenuAction(Context context, long[] fileDescriptors) {
-        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.new_empty_playlist);
+        super(context, R.drawable.contextmenu_icon_playlist_add_dark, R.string.new_empty_playlist, getTintColor(context)); // Updated super() call
         this.fileDescriptors = fileDescriptors;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/FileInformationAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/FileInformationAction.java
@@ -25,8 +25,6 @@ import android.os.Bundle;
 import android.widget.Button;
 import android.widget.TextView;
 
-import androidx.core.content.ContextCompat;
-
 import com.frostwire.android.R;
 import com.frostwire.android.core.FWFileDescriptor;
 import com.frostwire.android.gui.util.UIUtils;
@@ -51,13 +49,8 @@ public final class FileInformationAction extends MenuAction {
         super(context,
                 R.drawable.contextmenu_icon_file,
                 R.string.file_information,
-                getTintColor(context));
+                UIUtils.getAppIconPrimaryColor(context));
         this.fd = fd;
-    }
-
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/FileInformationAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/FileInformationAction.java
@@ -25,6 +25,8 @@ import android.os.Bundle;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
+
 import com.frostwire.android.R;
 import com.frostwire.android.core.FWFileDescriptor;
 import com.frostwire.android.gui.util.UIUtils;
@@ -46,8 +48,16 @@ public final class FileInformationAction extends MenuAction {
     private final FWFileDescriptor fd;
 
     public FileInformationAction(Context context, FWFileDescriptor fd) {
-        super(context, R.drawable.contextmenu_icon_file, R.string.file_information);
+        super(context,
+                R.drawable.contextmenu_icon_file,
+                R.string.file_information,
+                getTintColor(context));
         this.fd = fd;
+    }
+
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/OpenMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/OpenMenuAction.java
@@ -1,6 +1,6 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2022, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
-
-import androidx.core.content.ContextCompat;
 
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
@@ -43,7 +41,7 @@ public class OpenMenuAction extends MenuAction {
     private final int position;
 
     public OpenMenuAction(Context context, String title, String path, String mime) {
-        super(context, R.drawable.contextmenu_icon_open, title, getTintColor(context)); // Corrected super() call
+        super(context, R.drawable.contextmenu_icon_open, title, UIUtils.getAppIconPrimaryColor(context));
         this.path = path;
         this.mime = mime;
         this.fileType = -1;
@@ -52,7 +50,7 @@ public class OpenMenuAction extends MenuAction {
     }
 
     public OpenMenuAction(Context context, String path, String mime) {
-        super(context, R.drawable.contextmenu_icon_open, R.string.open, getTintColor(context)); // Corrected super() call
+        super(context, R.drawable.contextmenu_icon_open, R.string.open, UIUtils.getAppIconPrimaryColor(context));
         this.path = path;
         this.mime = mime;
         this.fileType = -1;
@@ -61,7 +59,7 @@ public class OpenMenuAction extends MenuAction {
     }
 
     public OpenMenuAction(Context context, FWFileDescriptor fwFileDescriptor, int position) {
-        super(context, R.drawable.contextmenu_icon_open, R.string.open, getTintColor(context)); // Corrected super() call
+        super(context, R.drawable.contextmenu_icon_open, R.string.open, UIUtils.getAppIconPrimaryColor(context));
         this.path = fwFileDescriptor.filePath;
         this.mime = fwFileDescriptor.mime;
         this.fileType = fwFileDescriptor.fileType;
@@ -70,17 +68,12 @@ public class OpenMenuAction extends MenuAction {
     }
 
     public OpenMenuAction(Context context, String title, FWFileDescriptor pictureFWFileDescriptor) {
-        super(context, R.drawable.contextmenu_icon_picture, title, getTintColor(context)); // Corrected super() call
+        super(context, R.drawable.contextmenu_icon_picture, title, UIUtils.getAppIconPrimaryColor(context));
         this.path = pictureFWFileDescriptor.filePath;
         this.mime = pictureFWFileDescriptor.mime;
         this.fileType = pictureFWFileDescriptor.fileType;
         this.fd = pictureFWFileDescriptor;
         this.position = -1;
-    }
-
-    // Method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/OpenMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/OpenMenuAction.java
@@ -19,6 +19,8 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
+import androidx.core.content.ContextCompat;
+
 import com.andrew.apollo.utils.MusicUtils;
 import com.frostwire.android.R;
 import com.frostwire.android.core.Constants;
@@ -41,7 +43,7 @@ public class OpenMenuAction extends MenuAction {
     private final int position;
 
     public OpenMenuAction(Context context, String title, String path, String mime) {
-        super(context, R.drawable.contextmenu_icon_open, R.string.open_menu_action, title);
+        super(context, R.drawable.contextmenu_icon_open, title, getTintColor(context)); // Corrected super() call
         this.path = path;
         this.mime = mime;
         this.fileType = -1;
@@ -50,7 +52,7 @@ public class OpenMenuAction extends MenuAction {
     }
 
     public OpenMenuAction(Context context, String path, String mime) {
-        super(context, R.drawable.contextmenu_icon_open, R.string.open);
+        super(context, R.drawable.contextmenu_icon_open, R.string.open, getTintColor(context)); // Corrected super() call
         this.path = path;
         this.mime = mime;
         this.fileType = -1;
@@ -59,7 +61,7 @@ public class OpenMenuAction extends MenuAction {
     }
 
     public OpenMenuAction(Context context, FWFileDescriptor fwFileDescriptor, int position) {
-        super(context, R.drawable.contextmenu_icon_open, R.string.open);
+        super(context, R.drawable.contextmenu_icon_open, R.string.open, getTintColor(context)); // Corrected super() call
         this.path = fwFileDescriptor.filePath;
         this.mime = fwFileDescriptor.mime;
         this.fileType = fwFileDescriptor.fileType;
@@ -67,14 +69,18 @@ public class OpenMenuAction extends MenuAction {
         this.position = position;
     }
 
-
     public OpenMenuAction(Context context, String title, FWFileDescriptor pictureFWFileDescriptor) {
-        super(context, R.drawable.contextmenu_icon_picture, R.string.open_menu_action, title);
+        super(context, R.drawable.contextmenu_icon_picture, title, getTintColor(context)); // Corrected super() call
         this.path = pictureFWFileDescriptor.filePath;
         this.mime = pictureFWFileDescriptor.mime;
         this.fileType = pictureFWFileDescriptor.fileType;
         this.fd = pictureFWFileDescriptor;
         this.position = -1;
+    }
+
+    // Method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/PauseDownloadMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/PauseDownloadMenuAction.java
@@ -20,6 +20,8 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.frostwire.android.R;
 import com.frostwire.android.gui.views.MenuAction;
 import com.frostwire.android.gui.views.TimerObserver;
@@ -35,8 +37,13 @@ public final class PauseDownloadMenuAction extends MenuAction {
     private final BittorrentDownload download;
 
     public PauseDownloadMenuAction(Context context, BittorrentDownload download) {
-        super(context, R.drawable.contextmenu_icon_pause_transfer, R.string.pause_torrent_menu_action);
+        super(context, R.drawable.contextmenu_icon_pause_transfer, R.string.pause_torrent_menu_action, getTintColor(context)); // Updated super() call
         this.download = download;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/PauseDownloadMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/PauseDownloadMenuAction.java
@@ -1,28 +1,25 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2013, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
-import androidx.core.content.ContextCompat; // Added import
-
 import com.frostwire.android.R;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
 import com.frostwire.android.gui.views.TimerObserver;
 import com.frostwire.transfers.BittorrentDownload;
@@ -30,20 +27,15 @@ import com.frostwire.transfers.BittorrentDownload;
 /**
  * @author gubatron
  * @author aldenml
- *
+ * @author marcelinkaaa
  */
 public final class PauseDownloadMenuAction extends MenuAction {
 
     private final BittorrentDownload download;
 
     public PauseDownloadMenuAction(Context context, BittorrentDownload download) {
-        super(context, R.drawable.contextmenu_icon_pause_transfer, R.string.pause_torrent_menu_action, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_pause_transfer, R.string.pause_torrent_menu_action, UIUtils.getAppIconPrimaryColor(context));
         this.download = download;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/RenameFileMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/RenameFileMenuAction.java
@@ -28,6 +28,8 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.frostwire.android.R;
 import com.frostwire.android.core.FWFileDescriptor;
 import com.frostwire.android.gui.Librarian;
@@ -52,9 +54,14 @@ public class RenameFileMenuAction extends MenuAction {
     }
 
     public RenameFileMenuAction(Context context, FWFileDescriptor fd, AbstractDialog.OnDialogClickListener clickListener) {
-        super(context, R.drawable.contextmenu_icon_rename, R.string.rename);
+        super(context, R.drawable.contextmenu_icon_rename, R.string.rename, getTintColor(context)); // Updated super() call
         this.fd = fd;
         this.dialogClickListener = clickListener;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override
@@ -64,7 +71,8 @@ public class RenameFileMenuAction extends MenuAction {
 
     private void showRenameFileDialog() {
         RenameFileMenuActionDialog.renameAction = this;
-        RenameFileMenuActionDialog.newInstance(getFilePath(), dialogClickListener).show(((Activity) getContext()).getFragmentManager());
+        RenameFileMenuActionDialog.newInstance(getFilePath(), dialogClickListener)
+                .show(((Activity) getContext()).getFragmentManager());
     }
 
     private boolean isValidFileName(String newFileName) {

--- a/android/src/com/frostwire/android/gui/adapters/menu/RenameFileMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/RenameFileMenuAction.java
@@ -1,20 +1,18 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
- * Marcelina Knitter (@marcelinkaaa)
- * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.frostwire.android.gui.adapters.menu;
@@ -27,8 +25,6 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-
-import androidx.core.content.ContextCompat; // Added import
 
 import com.frostwire.android.R;
 import com.frostwire.android.core.FWFileDescriptor;
@@ -54,14 +50,9 @@ public class RenameFileMenuAction extends MenuAction {
     }
 
     public RenameFileMenuAction(Context context, FWFileDescriptor fd, AbstractDialog.OnDialogClickListener clickListener) {
-        super(context, R.drawable.contextmenu_icon_rename, R.string.rename, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_rename, R.string.rename, UIUtils.getAppIconPrimaryColor(context));
         this.fd = fd;
         this.dialogClickListener = clickListener;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/ResumeDownloadMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/ResumeDownloadMenuAction.java
@@ -21,6 +21,8 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.frostwire.android.R;
 import com.frostwire.android.gui.NetworkManager;
 import com.frostwire.android.gui.dialogs.YesNoDialog;
@@ -43,9 +45,14 @@ public final class ResumeDownloadMenuAction extends MenuAction implements Abstra
 
 
     public ResumeDownloadMenuAction(Context context, BittorrentDownload download, int stringId) {
-        super(context, R.drawable.contextmenu_icon_play, stringId);
+        super(context, R.drawable.contextmenu_icon_play, stringId, getTintColor(context)); // Updated super() call
         this.download = download;
         this.onBittorrentConnectRunnable = new OnBittorrentConnectRunnable(this);
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/ResumeDownloadMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/ResumeDownloadMenuAction.java
@@ -1,12 +1,12 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 
-import androidx.core.content.ContextCompat; // Added import
-
 import com.frostwire.android.R;
 import com.frostwire.android.gui.NetworkManager;
 import com.frostwire.android.gui.dialogs.YesNoDialog;
@@ -36,6 +34,7 @@ import com.frostwire.transfers.BittorrentDownload;
 /**
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public final class ResumeDownloadMenuAction extends MenuAction implements AbstractDialog.OnDialogClickListener {
 
@@ -45,14 +44,9 @@ public final class ResumeDownloadMenuAction extends MenuAction implements Abstra
 
 
     public ResumeDownloadMenuAction(Context context, BittorrentDownload download, int stringId) {
-        super(context, R.drawable.contextmenu_icon_play, stringId, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_play, stringId, UIUtils.getAppIconPrimaryColor(context));
         this.download = download;
         this.onBittorrentConnectRunnable = new OnBittorrentConnectRunnable(this);
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/RetryDownloadAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/RetryDownloadAction.java
@@ -19,6 +19,8 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.frostwire.android.R;
 import com.frostwire.android.gui.transfers.InvalidTransfer;
 import com.frostwire.android.gui.transfers.TorrentFetcherDownload;
@@ -34,8 +36,13 @@ public class RetryDownloadAction extends MenuAction {
     private final Transfer transfer;
 
     public RetryDownloadAction(Context context, Transfer transfer) {
-        super(context, R.drawable.contextmenu_icon_download, R.string.retry);
+        super(context, R.drawable.contextmenu_icon_download, R.string.retry, getTintColor(context)); // Updated super() call
         this.transfer = transfer;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/RetryDownloadAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/RetryDownloadAction.java
@@ -1,6 +1,7 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2022, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
+ * Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,30 +20,26 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
-import androidx.core.content.ContextCompat; // Added import
-
 import com.frostwire.android.R;
 import com.frostwire.android.gui.transfers.InvalidTransfer;
 import com.frostwire.android.gui.transfers.TorrentFetcherDownload;
 import com.frostwire.android.gui.transfers.TransferManager;
+import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
 import com.frostwire.transfers.Transfer;
 
 /**
  * @author gubatron
+ * @author aldenml
+ * @author marcelinkaaa
  */
 public class RetryDownloadAction extends MenuAction {
 
     private final Transfer transfer;
 
     public RetryDownloadAction(Context context, Transfer transfer) {
-        super(context, R.drawable.contextmenu_icon_download, R.string.retry, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_download, R.string.retry, UIUtils.getAppIconPrimaryColor(context));
         this.transfer = transfer;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override
@@ -58,7 +55,6 @@ public class RetryDownloadAction extends MenuAction {
 
     private void retryTorrentFetcherDownload() {
         TorrentFetcherDownload tfd = (TorrentFetcherDownload) transfer;
-
         TransferManager.instance().downloadTorrent(
                 tfd.getTorrentDownloadInfo().getTorrentUrl(),
                 tfd.getTorrentFetcherListener(),

--- a/android/src/com/frostwire/android/gui/adapters/menu/SeedAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SeedAction.java
@@ -12,6 +12,8 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
+
 import com.frostwire.android.R;
 import com.frostwire.android.core.ConfigurationManager;
 import com.frostwire.android.core.Constants;
@@ -60,7 +62,7 @@ public class SeedAction extends MenuAction implements AbstractDialog.OnDialogCli
                        FWFileDescriptor fd,
                        BittorrentDownload existingBittorrentDownload,
                        Transfer transferToClear) {
-        super(context, R.drawable.contextmenu_icon_seed, R.string.seed);
+        super(context, R.drawable.contextmenu_icon_seed, R.string.seed, getTintColor(context));
         this.fd = fd;
         this.btDownload = existingBittorrentDownload;
         this.transferToClear = transferToClear;
@@ -215,7 +217,7 @@ public class SeedAction extends MenuAction implements AbstractDialog.OnDialogCli
                 // due to the android providers getting out of sync.
             }
         } else {
-            async(this::buildTorrentAndSeedIt,fd);
+            async(this::buildTorrentAndSeedIt, fd);
         }
     }
 
@@ -321,5 +323,10 @@ public class SeedAction extends MenuAction implements AbstractDialog.OnDialogCli
                 newNoWifiInformationDialogRef.get().dismiss();
             }
         }
+    }
+
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 }

--- a/android/src/com/frostwire/android/gui/adapters/menu/SeedAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SeedAction.java
@@ -1,4 +1,19 @@
-
+/*
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.frostwire.android.gui.adapters.menu;
 
@@ -11,8 +26,6 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
-
-import androidx.core.content.ContextCompat;
 
 import com.frostwire.android.R;
 import com.frostwire.android.core.ConfigurationManager;
@@ -45,6 +58,7 @@ import java.lang.ref.WeakReference;
 /**
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public class SeedAction extends MenuAction implements AbstractDialog.OnDialogClickListener {
 
@@ -62,7 +76,7 @@ public class SeedAction extends MenuAction implements AbstractDialog.OnDialogCli
                        FWFileDescriptor fd,
                        BittorrentDownload existingBittorrentDownload,
                        Transfer transferToClear) {
-        super(context, R.drawable.contextmenu_icon_seed, R.string.seed, getTintColor(context));
+        super(context, R.drawable.contextmenu_icon_seed, R.string.seed, UIUtils.getAppIconPrimaryColor(context));
         this.fd = fd;
         this.btDownload = existingBittorrentDownload;
         this.transferToClear = transferToClear;
@@ -323,10 +337,5 @@ public class SeedAction extends MenuAction implements AbstractDialog.OnDialogCli
                 newNoWifiInformationDialogRef.get().dismiss();
             }
         }
-    }
-
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 }

--- a/android/src/com/frostwire/android/gui/adapters/menu/SendBitcoinTipAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SendBitcoinTipAction.java
@@ -1,12 +1,12 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
-import androidx.core.content.ContextCompat;
-
 import com.frostwire.android.R;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
@@ -32,6 +30,7 @@ import com.frostwire.android.gui.views.MenuAction;
  *
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public final class SendBitcoinTipAction extends MenuAction {
 
@@ -41,13 +40,8 @@ public final class SendBitcoinTipAction extends MenuAction {
         super(context,
                 R.drawable.contextmenu_icon_donation_bitcoin,
                 R.string.send_bitcoin_tip,
-                getTintColor(context));
+                UIUtils.getAppIconPrimaryColor(context));
         this.bitcoinUrl = bitcoinUrl;
-    }
-
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/SendBitcoinTipAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SendBitcoinTipAction.java
@@ -21,6 +21,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
+import androidx.core.content.ContextCompat;
+
 import com.frostwire.android.R;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
@@ -36,8 +38,16 @@ public final class SendBitcoinTipAction extends MenuAction {
     private final String bitcoinUrl;
 
     public SendBitcoinTipAction(Context context, String bitcoinUrl) {
-        super(context, R.drawable.contextmenu_icon_donation_bitcoin, R.string.send_bitcoin_tip);
+        super(context,
+                R.drawable.contextmenu_icon_donation_bitcoin,
+                R.string.send_bitcoin_tip,
+                getTintColor(context));
         this.bitcoinUrl = bitcoinUrl;
+    }
+
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/SendFiatTipAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SendFiatTipAction.java
@@ -1,12 +1,12 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
-import androidx.core.content.ContextCompat; // Added import
-
 import com.frostwire.android.R;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
@@ -30,19 +28,15 @@ import com.frostwire.android.gui.views.MenuAction;
 /**
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public final class SendFiatTipAction extends MenuAction {
 
     private final String paypalUrl;
 
     public SendFiatTipAction(Context context, String paypalUrl) {
-        super(context, R.drawable.contextmenu_icon_donation_fiat, R.string.send_tip_donation, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_donation_fiat, R.string.send_tip_donation, UIUtils.getAppIconPrimaryColor(context));
         this.paypalUrl = paypalUrl;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/SendFiatTipAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SendFiatTipAction.java
@@ -21,6 +21,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.frostwire.android.R;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
@@ -34,8 +36,13 @@ public final class SendFiatTipAction extends MenuAction {
     private final String paypalUrl;
 
     public SendFiatTipAction(Context context, String paypalUrl) {
-        super(context, R.drawable.contextmenu_icon_donation_fiat, R.string.send_tip_donation);
+        super(context, R.drawable.contextmenu_icon_donation_fiat, R.string.send_tip_donation, getTintColor(context)); // Updated super() call
         this.paypalUrl = paypalUrl;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/SendFileMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SendFileMenuAction.java
@@ -22,6 +22,8 @@ import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.frostwire.android.R;
 import com.frostwire.android.core.FWFileDescriptor;
 import com.frostwire.android.core.providers.TableFetcher;
@@ -41,9 +43,14 @@ public class SendFileMenuAction extends MenuAction {
     private final FWFileDescriptor fd;
 
     public SendFileMenuAction(Context context, FWFileDescriptor fd) {
-        super(context, R.drawable.contextmenu_icon_send, R.string.share);
+        super(context, R.drawable.contextmenu_icon_send, R.string.share, getTintColor(context)); // Updated super() call
 
         this.fd = fd;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/SendFileMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SendFileMenuAction.java
@@ -1,6 +1,6 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2022, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import com.frostwire.android.gui.views.MenuAction;
 /**
  * @author gubatron
  * @author aldenml
- *
+ * @author marcelinkaaa
  */
 public class SendFileMenuAction extends MenuAction {
 
@@ -43,14 +43,8 @@ public class SendFileMenuAction extends MenuAction {
     private final FWFileDescriptor fd;
 
     public SendFileMenuAction(Context context, FWFileDescriptor fd) {
-        super(context, R.drawable.contextmenu_icon_send, R.string.share, getTintColor(context)); // Updated super() call
-
+        super(context, R.drawable.contextmenu_icon_send, R.string.share, UIUtils.getAppIconPrimaryColor(context));
         this.fd = fd;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/SetAsWallpaperMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SetAsWallpaperMenuAction.java
@@ -22,6 +22,8 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.frostwire.android.R;
 import com.frostwire.android.core.Constants;
 import com.frostwire.android.core.FWFileDescriptor;
@@ -39,8 +41,13 @@ public class SetAsWallpaperMenuAction extends MenuAction {
     private final FWFileDescriptor fd;
 
     public SetAsWallpaperMenuAction(Context context, FWFileDescriptor fd) {
-        super(context, R.drawable.contextmenu_icon_picture, R.string.set_as_wallpaper);
+        super(context, R.drawable.contextmenu_icon_picture, R.string.set_as_wallpaper, getTintColor(context)); // Updated super() call
         this.fd = fd;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/SetAsWallpaperMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/SetAsWallpaperMenuAction.java
@@ -1,6 +1,6 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2018, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 
 package com.frostwire.android.gui.adapters.menu;
 
+import static com.frostwire.android.util.Asyncs.async;
+
 import android.app.WallpaperManager;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-
-import androidx.core.content.ContextCompat; // Added import
 
 import com.frostwire.android.R;
 import com.frostwire.android.core.Constants;
@@ -30,24 +30,18 @@ import com.frostwire.android.core.FWFileDescriptor;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.MenuAction;
 
-import static com.frostwire.android.util.Asyncs.async;
-
 /**
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public class SetAsWallpaperMenuAction extends MenuAction {
 
     private final FWFileDescriptor fd;
 
     public SetAsWallpaperMenuAction(Context context, FWFileDescriptor fd) {
-        super(context, R.drawable.contextmenu_icon_picture, R.string.set_as_wallpaper, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_picture, R.string.set_as_wallpaper, UIUtils.getAppIconPrimaryColor(context));
         this.fd = fd;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/StopSeedingAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/StopSeedingAction.java
@@ -19,6 +19,8 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
+import androidx.core.content.ContextCompat;
+
 import com.frostwire.android.R;
 import com.frostwire.android.gui.transfers.TransferManager;
 import com.frostwire.android.gui.util.UIUtils;
@@ -41,9 +43,17 @@ public class StopSeedingAction extends MenuAction {
     private StopSeedingAction(Context context,
                               BittorrentDownload existingBittorrentDownload,
                               @SuppressWarnings("SameParameterValue") Transfer transferToClear) {
-        super(context, R.drawable.contextmenu_icon_seed, R.string.seed_stop);
+        super(context,
+                R.drawable.contextmenu_icon_seed,
+                R.string.seed_stop,
+                getTintColor(context));
         this.btDownload = existingBittorrentDownload;
         this.transferToClear = transferToClear;
+    }
+
+    // Method to retrieve the tint color from resources
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/StopSeedingAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/StopSeedingAction.java
@@ -1,6 +1,6 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2022, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ package com.frostwire.android.gui.adapters.menu;
 
 import android.content.Context;
 
-import androidx.core.content.ContextCompat;
-
 import com.frostwire.android.R;
 import com.frostwire.android.gui.transfers.TransferManager;
 import com.frostwire.android.gui.util.UIUtils;
@@ -34,6 +32,7 @@ import com.frostwire.util.Logger;
 /**
  * @author gubatron
  * @author aldenml
+ * @author marcelinkaaa
  */
 public class StopSeedingAction extends MenuAction {
     private static final Logger LOG = Logger.getLogger(StopSeedingAction.class);
@@ -46,15 +45,11 @@ public class StopSeedingAction extends MenuAction {
         super(context,
                 R.drawable.contextmenu_icon_seed,
                 R.string.seed_stop,
-                getTintColor(context));
+                UIUtils.getAppIconPrimaryColor(context));
         this.btDownload = existingBittorrentDownload;
         this.transferToClear = transferToClear;
     }
 
-    // Method to retrieve the tint color from resources
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
-    }
 
     @Override
     public void onClick(Context context) {

--- a/android/src/com/frostwire/android/gui/adapters/menu/TransferDetailsMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/TransferDetailsMenuAction.java
@@ -1,13 +1,13 @@
 /*
  * Created by Angel Leon (@gubatron), Alden Torres (aldenml),
- *            Jose Molina (@votaguz)
- * Copyright (c) 2011-2017, FrostWire(R). All rights reserved.
+ *            Jose Molina (@votaguz), Marcelina Knitter (@marcelinkaaa)
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,6 +36,7 @@ import java.lang.ref.WeakReference;
  * @author gubatron
  * @author aldenml
  * @author votaguz
+ * @author marcelinkaaa
  */
 public class TransferDetailsMenuAction extends MenuAction {
 

--- a/android/src/com/frostwire/android/gui/adapters/menu/TransferDetailsMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/TransferDetailsMenuAction.java
@@ -22,8 +22,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.view.View;
 
-import androidx.core.content.ContextCompat; // Added import
-
 import com.frostwire.android.R;
 import com.frostwire.android.gui.activities.TransferDetailActivity;
 import com.frostwire.android.gui.util.UIUtils;
@@ -44,13 +42,8 @@ public class TransferDetailsMenuAction extends MenuAction {
     private WeakReference<View> clickedViewRef; // used for possible toast message
 
     public TransferDetailsMenuAction(Context context, int stringId, String infoHash) {
-        super(context, R.drawable.contextmenu_icon_file, stringId, getTintColor(context)); // Updated super() call
+        super(context, R.drawable.contextmenu_icon_file, stringId, UIUtils.getAppIconPrimaryColor(context));
         this.infohash = infoHash;
-    }
-
-    // Added method to retrieve tint color
-    private static int getTintColor(Context context) {
-        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/adapters/menu/TransferDetailsMenuAction.java
+++ b/android/src/com/frostwire/android/gui/adapters/menu/TransferDetailsMenuAction.java
@@ -22,6 +22,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.view.View;
 
+import androidx.core.content.ContextCompat; // Added import
+
 import com.frostwire.android.R;
 import com.frostwire.android.gui.activities.TransferDetailActivity;
 import com.frostwire.android.gui.util.UIUtils;
@@ -41,8 +43,13 @@ public class TransferDetailsMenuAction extends MenuAction {
     private WeakReference<View> clickedViewRef; // used for possible toast message
 
     public TransferDetailsMenuAction(Context context, int stringId, String infoHash) {
-        super(context, R.drawable.contextmenu_icon_file, stringId);
+        super(context, R.drawable.contextmenu_icon_file, stringId, getTintColor(context)); // Updated super() call
         this.infohash = infoHash;
+    }
+
+    // Added method to retrieve tint color
+    private static int getTintColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 
     @Override

--- a/android/src/com/frostwire/android/gui/fragments/preference/SearchEnginesPreferenceFragment.java
+++ b/android/src/com/frostwire/android/gui/fragments/preference/SearchEnginesPreferenceFragment.java
@@ -19,7 +19,6 @@ package com.frostwire.android.gui.fragments.preference;
 
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceGroupAdapter;
 import androidx.preference.PreferenceScreen;
@@ -31,7 +30,6 @@ import com.frostwire.android.gui.SearchEngine;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.AbstractPreferenceFragment;
 
-import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,7 +165,7 @@ public final class SearchEnginesPreferenceFragment extends AbstractPreferenceFra
         CheckedAwarePreferenceGroupAdapter(PreferenceGroup preferenceGroup) {
             super(preferenceGroup);
             this.checkedDrawableId = R.color.app_selection_background;
-            this.unCheckedDrawableId = R.color.basic_white;
+            this.unCheckedDrawableId = R.color.basic_background;
         }
 
         @Override

--- a/android/src/com/frostwire/android/gui/util/UIUtils.java
+++ b/android/src/com/frostwire/android/gui/util/UIUtils.java
@@ -46,6 +46,7 @@ import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import androidx.annotation.StringRes;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 
 import com.andrew.apollo.utils.MusicUtils;
@@ -649,5 +650,9 @@ public final class UIUtils {
             } catch (Throwable ignored) {
             }
         }
+    }
+
+    public static int getAppIconPrimaryColor(Context context) {
+        return ContextCompat.getColor(context, R.color.app_icon_primary);
     }
 }

--- a/android/src/com/frostwire/android/gui/views/MenuAction.java
+++ b/android/src/com/frostwire/android/gui/views/MenuAction.java
@@ -1,12 +1,12 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml)
- * Copyright (c) 2011-2016, FrostWire(R). All rights reserved.
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelina), and FrostWire
+ * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -67,14 +67,18 @@ public abstract class MenuAction {
     }
 
     public final void onClick() {
-        Context context = contextRef.get();
+        Context context = getContext();
         if (context != null) {
             onClick(context);
         }
     }
 
     public Context getContext() {
-        return contextRef.get();
+        Context result = null;
+        if (Ref.alive(contextRef)) {
+            result = contextRef.get();
+        }
+        return result;
     }
 
     public abstract void onClick(Context context);

--- a/android/src/com/frostwire/android/gui/views/MenuAction.java
+++ b/android/src/com/frostwire/android/gui/views/MenuAction.java
@@ -20,6 +20,9 @@ package com.frostwire.android.gui.views;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+
 import com.frostwire.util.Ref;
 
 import java.lang.ref.WeakReference;
@@ -35,22 +38,24 @@ public abstract class MenuAction {
     private final Drawable image;
     private final String text;
 
-    public MenuAction(Context context, Drawable image, String text) {
+    public MenuAction(Context context, int imageId, String text, int tintColor) {
         this.contextRef = new WeakReference<>(context);
-        this.image = image;
+
+        Drawable drawable = ContextCompat.getDrawable(context, imageId);
+        if (drawable != null) {
+            drawable = DrawableCompat.wrap(drawable).mutate();
+            DrawableCompat.setTint(drawable, tintColor);
+        }
+        this.image = drawable;
         this.text = text;
     }
 
-    public MenuAction(Context context, int imageId, String text) {
-        this(context, context.getResources().getDrawable(imageId), text);
+    public MenuAction(Context context, int imageId, int textId, int tintColor) {
+        this(context, imageId, context.getResources().getString(textId), tintColor);
     }
 
-    public MenuAction(Context context, int imageId, int textId) {
-        this(context, context.getResources().getDrawable(imageId), context.getResources().getString(textId));
-    }
-
-    public MenuAction(Context context, int imageId, int textId, Object... formatArgs) {
-        this(context, imageId, context.getResources().getString(textId, formatArgs));
+    public MenuAction(Context context, int imageId, int textId, int tintColor, Object... formatArgs) {
+        this(context, imageId, context.getResources().getString(textId, formatArgs), tintColor);
     }
 
     public String getText() {
@@ -62,17 +67,14 @@ public abstract class MenuAction {
     }
 
     public final void onClick() {
-        if (contextRef.get() != null) {
-            onClick(contextRef.get());
+        Context context = contextRef.get();
+        if (context != null) {
+            onClick(context);
         }
     }
 
     public Context getContext() {
-        Context result = null;
-        if (Ref.alive(contextRef)) {
-            result = contextRef.get();
-        }
-        return result;
+        return contextRef.get();
     }
 
     public abstract void onClick(Context context);

--- a/android/src/com/frostwire/android/gui/views/MenuAction.java
+++ b/android/src/com/frostwire/android/gui/views/MenuAction.java
@@ -38,11 +38,8 @@ public abstract class MenuAction {
     private final Drawable image;
     private final String text;
 
-    private final int tintColor;
-
     public MenuAction(Context context, int imageId, String text, int tintColor) {
         this.contextRef = new WeakReference<>(context);
-        this.tintColor = tintColor;
 
         Drawable drawable = ContextCompat.getDrawable(context, imageId);
         if (drawable != null) {
@@ -67,10 +64,6 @@ public abstract class MenuAction {
 
     public Drawable getImage() {
         return image;
-    }
-
-    public int getTintColor() {
-        return tintColor;
     }
 
     public final void onClick() {

--- a/android/src/com/frostwire/android/gui/views/MenuAction.java
+++ b/android/src/com/frostwire/android/gui/views/MenuAction.java
@@ -1,5 +1,5 @@
 /*
- * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelina), and FrostWire
+ * Created by Angel Leon (@gubatron), Alden Torres (aldenml), Marcelina Knitter (@marcelinkaaa)
  * Copyright (c) 2011-2024, FrostWire(R). All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ import java.lang.ref.WeakReference;
 /**
  * @author gubatron
  * @author aldenml
- *
+ * @author marcelinkaaa
  */
 public abstract class MenuAction {
 
@@ -38,8 +38,11 @@ public abstract class MenuAction {
     private final Drawable image;
     private final String text;
 
+    private final int tintColor;
+
     public MenuAction(Context context, int imageId, String text, int tintColor) {
         this.contextRef = new WeakReference<>(context);
+        this.tintColor = tintColor;
 
         Drawable drawable = ContextCompat.getDrawable(context, imageId);
         if (drawable != null) {
@@ -64,6 +67,10 @@ public abstract class MenuAction {
 
     public Drawable getImage() {
         return image;
+    }
+
+    public int getTintColor() {
+        return tintColor;
     }
 
     public final void onClick() {

--- a/android/src/com/frostwire/android/gui/views/RichNotificationActionLink.java
+++ b/android/src/com/frostwire/android/gui/views/RichNotificationActionLink.java
@@ -64,7 +64,7 @@ public class RichNotificationActionLink {
             SpannableString text = new SpannableString(getText());
             text.setSpan(new UnderlineSpan(), 0, text.length(), 0);
             tv.setText(text);
-            tv.setTextColor(contextReference.get().getResources().getColor(R.color.basic_blue));
+            tv.setTextColor(contextReference.get().getResources().getColor(R.color.basic_color));
             tv.setOnClickListener(getClickAdapter());
             tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15.0f);
             result = tv;


### PR DESCRIPTION
Continuation from [Pull 109](https://github.com/frostwire/frostwire/pull/1019) by @marcelinkaaa (A million thanks for this work, it's one of the most requested features I couldn't ever deliver)

![image](https://github.com/user-attachments/assets/7635e443-bf3b-49d6-8cfa-8032c69b7d82)

![image](https://github.com/user-attachments/assets/8f7fc26e-c525-4c65-9688-802f9602dcd0)

![image](https://github.com/user-attachments/assets/cdd95efe-7490-4fdc-8146-56edcda70ddf)

![image](https://github.com/user-attachments/assets/c2a46dc5-ae2b-418b-a2ac-d896590498a3)

![image](https://github.com/user-attachments/assets/142b477f-b336-47d8-b461-56d8ca1299a8)

"Mostly tested on API 33. On API 28 the app would crash sometimes on the music player citing something about an ad size - it should not be related to this branch.

I added night theme colors. Updated tint of icons, color of text, and backgrounds. Updated custom styles for toolbars, etc.
I also added a UI for added Dark Theme in preferences, but at this point, I don't think I can make it work on my own. Maybe you could add it to preferences. For now it works if a user changes to Dark Theme from phone settings. Let me know what you think, and if you want it." -@marcelinkaaa

Let's hope I can replicate those crashes now
