### PR TITLE
(Actually) Fix search bar clear button overlap

### DIFF
--- a/desktop/src/com/frostwire/gui/searchfield/BuddySupport.java
+++ b/desktop/src/com/frostwire/gui/searchfield/BuddySupport.java
@@ -66,16 +66,11 @@ public class BuddySupport {
     }
 
     private static void addToComponentHierarchy(Component c, Position pos, JTextField textField) {
-        // make sure the wrapper set the layout, but be defensive:
-        if (!(textField.getLayout() instanceof BorderLayout)) {
-            textField.setLayout(new BorderLayout());
+        try {
+            textField.add(c, pos.constraint);
+        } catch (NullPointerException e) {
+            System.err.println("ERROR: BuddySupport: Attempted to add null component to hierarchy.");
         }
-
-        Object constraint = (pos == Position.LEFT)
-                ? BorderLayout.LINE_START    // LTR = West, RTL = East
-                : BorderLayout.LINE_END;     // LTR = East, RTL = West
-
-        textField.add(c, pos.constraint);
     }
 
     static List<Component> getLeft(JTextField textField) {


### PR DESCRIPTION
Fixes #1044.

This PR simply reverts changes (mostly) made to `BuddySupport.addToComponentHierarchy()` in commit 0a9f7fae5ada95544e4767ca36b3801b996a1f70. From what I understand, that commit introduced proper theme switching and a few refactors. As a part of those refactors (I assume), `BuddySupport.addtoComponentHierarchy()` was made to ensure that `textField` had a `BorderLayout`. If it didn't, it would give it a new `BorderLayout`. However, this caused both the issue in #1044 and also the search icon not to appear.

The primary differences between this PR and the aforementioned method prior to 0a9f7fae5ada95544e4767ca36b3801b996a1f70 is that we use `pos.constraint` (as introduced in that commit) and we also explicitly handle a `NullPointerException` with a nice error message. Might as well give some indication that something happened :P

I'm not sure why we had to ensure that the text field had a `BorderLayout`. It seems that things worked fine previously, but if there's a reason, then likely there's a deeper issue that needs to be straightened out. Hopefully this was just a simple mistake and not a reflection of something larger.

Finally, a little word on #1050. In [this issue comment](https://github.com/frostwire/frostwire/issues/1044#issuecomment-3239773313), I state that, essentially, AI was only able to see the issue at a surface level. To further expand on that, I think this issue makes a good example of how AI has its limitations. Indeed, AI can do some tasks (really) well, and in #1048 I believe that PR should work fine. At the same time, it still has its limitations as clearly showcased in #1050, so I say proceed with caution. Don't forget about the other concerns regarding AI too. Overall, AI can be a great tool, but it still has notable limitations, so do inspect any AI-generated code closely should you choose to use it for that purpose.