### PR TITLE
Make settings window content scrollable

### DIFF
--- a/desktop/src/com/limegroup/gnutella/gui/options/OptionsConstructor.java
+++ b/desktop/src/com/limegroup/gnutella/gui/options/OptionsConstructor.java
@@ -160,8 +160,12 @@ public final class OptionsConstructor {
         Component treeComponent = TREE_MANAGER.getComponent();
         treePanel.add(treeComponent);
         Component paneComponent = paneManager.getComponent();
+
+        // Setup the settings content
+        JScrollPane scrollPanel = new JScrollPane(paneComponent);
         splitBox.add(treePanel);
-        splitBox.add(paneComponent);
+        splitBox.add(scrollPanel);
+
         mainPanel.add(splitBox);
         mainPanel.add(Box.createVerticalStrut(17));
         mainPanel.add(new OptionsButtonPanel().getComponent());


### PR DESCRIPTION
In #1056, I showed off screenshots of a scrollable settings window. Now, this PR makes that reality. The settings window is now automatically scrollable and properly fits everything on displays with resolutions such as 1366x768 (my laptop's current display resolution). For higher resolution displays, it doesn't matter as much, but I think it makes a good quality change! :D