### PR TITLE
Fix Archive.org search provider

### DIFF
--- a/common/src/main/java/com/frostwire/search/archiveorg/ArchiveorgSearchPerformer.java
+++ b/common/src/main/java/com/frostwire/search/archiveorg/ArchiveorgSearchPerformer.java
@@ -47,7 +47,7 @@ public class ArchiveorgSearchPerformer extends CrawlPagedWebSearchPerformer<Arch
                 + getDomainName()
                 + "/advancedsearch.php?q="
                 + encodedKeywords
-                + "&fl[]=avg_rating&fl[]=call_number&fl[]=collection&fl[]=contributor&fl[]=coverage&fl[]=creator&fl[]=date&fl[]=description&fl[]=downloads&fl[]=foldoutcount&fl[]=format&fl[]=headerImage&fl[]=identifier&fl[]=imagecount&fl[]=language&fl[]=licenseurl&fl[]=mediatype&fl[]=month&fl[]=num_reviews&fl[]=oai_updatedate&fl[]=publicdate&fl[]=publisher&fl[]=rights&fl[]=scanningcentre&fl[]=source&fl[]=title&fl[]=type&fl[]=volume&fl[]=week&fl[]=year&rows=50&page=1&indent=yes&output=json";
+                + "&fl[]=avg_rating&fl[]=call_number&fl[]=collection&fl[]=contributor&fl[]=coverage&fl[]=creator&fl[]=date&fl[]=description&fl[]=downloads&fl[]=foldoutcount&fl[]=format&fl[]=headerImage&fl[]=identifier&fl[]=imagecount&fl[]=language&fl[]=licenseurl&fl[]=mediatype&fl[]=month&fl[]=num_reviews&fl[]=oai_updatedate&fl[]=publicdate&fl[]=publisher&fl[]=rights&fl[]=scanningcentre&fl[]=source&fl[]=title&fl[]=type&fl[]=volume&fl[]=week&fl[]=year&rows=50&page=1&output=json";
         //sort[]=downloads+desc&sort[]=createdate+desc
         //sort[]=avg_rating+desc&
     }


### PR DESCRIPTION
I was wondering why FrostWire's Archive.org search provider didn't work, so I decided to investigate this. It turns out the issue was really simple: an invalid argument was being passed to the `indent` parameter. Since I didn't know what valid values this parameter accepted, I decided to remove it. In doing so, searching Archive.org from FrostWire works again! Now FrostWire has one more working search provider! 🎉 