### PR TITLE
Fix Linux build

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     if (os.isWindows()) {
         implementation "com.frostwire:jlibtorrent-windows:${jlibtorrent_version}"
     } else if (os.isLinux()) {
-        implementation "com.frostwire:jlibtorrent-linux64:${jlibtorrent_version}"
+        implementation "com.frostwire:jlibtorrent-linux:${jlibtorrent_version}"
     } else if (os.isMacOsX()) {
         // if it's arm mac
         if (is_arm64) {


### PR DESCRIPTION
This is taken from #1058, specifically commit 93c52c60ba90bc6d1e408033d96fb093902c115a. Turns out this can be applied to `master` also. It simply fixes the Linux build for now.

I think I should've done this PR from the start first, and then have #1058 merged also into `master`. That should be an easy fix though since that PR was squashed and merged into `jlibtorrent-2.0-migration`.