### PR TITLE
Proof-of-Concept: Rearrange the header bar

### DIFF
--- a/desktop/src/com/limegroup/gnutella/gui/ApplicationHeader.java
+++ b/desktop/src/com/limegroup/gnutella/gui/ApplicationHeader.java
@@ -81,19 +81,27 @@ public final class ApplicationHeader extends JPanel implements RefreshListener {
         setLayout(new MigLayout("ins 0, ay 50%, filly,", "[][][grow][][]"));
         headerButtonBackgroundSelected = GUIMediator.getThemeImage("selected_header_button_background").getImage();
         headerButtonBackgroundUnselected = GUIMediator.getThemeImage("unselected_header_button_background").getImage();
-        cloudSearchField = new GoogleSearchField();
-        searchPanels = createSearchPanel();
-        searchPanels.setOpaque(false);
-        add(searchPanels, "wmin 250px, wmax 450px, growprio 50, growx, gapright 10px, gapleft 5px");
-        addTabButtons(tabs);
-        createUpdateButton();
+
+        // Setup the program logo and update buttons
         JPanel logoUpdateButtonsPanel = new JPanel();
         logoUpdateButtonsPanel.setOpaque(false);
         logoPanel = new LogoPanel();
+        createUpdateButton();
         //only one will be shown at the time.
         logoUpdateButtonsPanel.add(logoPanel);
         logoUpdateButtonsPanel.add(updateButton);
         add(logoUpdateButtonsPanel, "growx, alignx center");
+
+        // Setup the tab buttons
+        addTabButtons(tabs);
+
+        // Setup the search field
+        cloudSearchField = new GoogleSearchField();
+        searchPanels = createSearchPanel();
+        searchPanels.setOpaque(false);
+        add(searchPanels, "alignx center, growx");
+
+        // Setup the media player
         JComponent player = new MediaPlayerComponent().getMediaPanel();
         player.setOpaque(false);
         add(player, "dock east, growy, gapafter 10px!");

--- a/desktop/src/com/limegroup/gnutella/gui/init/WelcomeWindow.java
+++ b/desktop/src/com/limegroup/gnutella/gui/init/WelcomeWindow.java
@@ -70,7 +70,6 @@ final class WelcomeWindow extends SetupWindow {
         GridBagConstraints c = new GridBagConstraints();
         com.limegroup.gnutella.gui.MultiLineLabel label1 = new com.limegroup.gnutella.gui.MultiLineLabel(text1, 400);
         label1.setFont(label1.getFont().deriveFont(16f));
-        label1.setForeground(GUIUtils.hexToColor("333333"));
         c.anchor = GridBagConstraints.WEST;
         c.fill = GridBagConstraints.HORIZONTAL;
         c.gridwidth = GridBagConstraints.REMAINDER;
@@ -79,7 +78,6 @@ final class WelcomeWindow extends SetupWindow {
         panel.add(label1, c);
         com.limegroup.gnutella.gui.MultiLineLabel label2 = new com.limegroup.gnutella.gui.MultiLineLabel(text2, 400);
         label2.setFont(label2.getFont().deriveFont(16f));
-        label2.setForeground(GUIUtils.hexToColor("333333"));
         c.anchor = GridBagConstraints.WEST;
         c.fill = GridBagConstraints.HORIZONTAL;
         c.gridwidth = GridBagConstraints.REMAINDER;
@@ -88,7 +86,6 @@ final class WelcomeWindow extends SetupWindow {
         panel.add(label2, c);
         com.limegroup.gnutella.gui.MultiLineLabel label3 = new com.limegroup.gnutella.gui.MultiLineLabel(I18n.tr("FrostWire is free software,") + " ", 400);
         label3.setFont(label3.getFont().deriveFont(16f));
-        label3.setForeground(GUIUtils.hexToColor("333333"));
         c.anchor = GridBagConstraints.LINE_START;
         c.gridwidth = 1;
         c.weightx = 0;
@@ -96,7 +93,6 @@ final class WelcomeWindow extends SetupWindow {
         panel.add(label3, c);
         URLLabel findMore = new URLLabel("http://www.frostwire.com/scams", I18n.tr("Do not pay for FrostWire."));
         findMore.setFont(findMore.getFont().deriveFont(16f));
-        findMore.setForeground(GUIUtils.hexToColor("333333"));
         c.anchor = GridBagConstraints.LINE_START;
         c.gridwidth = GridBagConstraints.REMAINDER;
         c.weightx = 1.0;


### PR DESCRIPTION
I had initially mean to investigate theme tweaks across different themes in FrostWire to improve the experience. However, I got side tracked and thought of rearranging the application header bar. This is what it now looks like:

<img width="1540" height="976" alt="image" src="https://github.com/user-attachments/assets/f7a01185-a5bc-48ad-80f9-e0689b16f3bd" />

Yes, this looks rather crude, but I thought it'd be a good experiment to showcase regarding FrostWire's design. For now, I'm keeping PR a draft because a) it's meant only as a proof-of-concept (though we can merge it later if desired), and b) because it's based off an incomplete theme tweaks branch (aimed at tackling #1094 plus other things).

# Rationale
The purpose of rearranging the header bar this way is to emphasize FrostWire's search functionality, which I think is _the_ flagship feature of FrostWire. With a larger search bar, I think this allows users to notice FrostWire's search funcitonality much more than previously before. Additionally, it takes up the mounds of usable space left previously by the logo being centered. I still kept the logo in the header bar, however, just to keep it there. Personally, I would remove it, but I also recognize its importance.

Am I a UI/UX designer? **Absolutely not**. However, I did try to be creative in justifying this change. Do I expect this PR to be merged? Also no. It's mainly meant for people to play with it. However, if it works great, then it certainly _can_ be merged!