### PR TITLE
[common/desktop] Update dependencies

### DIFF
--- a/common/dependencies.gradle
+++ b/common/dependencies.gradle
@@ -1,8 +1,8 @@
 dependencies {
     // @Nullable cross-os annotation
-    implementation 'org.jetbrains:annotations:26.0.1'
+    implementation 'org.jetbrains:annotations:26.0.2'
 
-    implementation 'com.google.re2j:re2j:1.7'
-    implementation 'com.google.code.gson:gson:2.10'
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.google.re2j:re2j:1.8'
+    implementation 'com.google.code.gson:gson:2.13.2'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 }

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -80,13 +80,13 @@ repositories {
 
 dependencies {
     // @Nullable cross-os annotation
-    implementation 'org.jetbrains:annotations:26.0.1'
+    implementation 'org.jetbrains:annotations:26.0.2'
 
     implementation 'com.google.re2j:re2j:1.8'
-    implementation 'com.google.code.gson:gson:2.10'
+    implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.googlecode.gettext-commons:gettext-commons:0.9.8'
-    implementation 'org.xerial:sqlite-jdbc:3.43.0.0'
+    implementation 'org.xerial:sqlite-jdbc:3.50.3.0'
 
 
     def jlibtorrent_version = '2.0.12.5'


### PR DESCRIPTION
This is a quick PR that upgrades a few dependencies to their latest versions across both common and desktop. The following dependencies have been upgraded to the following versions:

- Update org.jetbrains.annotations to 26.0.2
- Update com.google.re2j to 1.8
- Update com.google.gson to 2.13.2
- Update com.squareup.okhttp3 to 4.12.0
- Update org.xerial:sqlite-jdbc to 3.50.3.0

Food for thought: maybe deduplicate dependencies across the Android and desktop versions. I'm not sure how well that may work out, but I might attempt it soon.