### PR TITLE
[desktop] Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -44,6 +44,10 @@ jobs:
     - name: Build with Gradle
       run: cd desktop && ./gradlew build
 
+    - name: "[Linux] Build JAR"
+      if: runner.os != 'Windows' && runner.os != 'macOS'
+      run: ./gradlew jar
+
     # Uncomment the following step to enable publishing builds when a release is made.
     #
     # The USERNAME and TOKEN need to correspond to the credentials environment variables used in


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow that builds FrostWire on Ubuntu. Note that it only builds on Ubuntu each time there's a push or pull request to `master`, but I hope it makes it easier to determine if a pull request builds or not. Additionally, we can have the same thing performed on Windows or macOS with no difference, but I'm okay if this PR is merged before I get to do that.

Not only will this workflow be helpful in testing if whether or not FrostWire builds, but it will also open the door to nightly builds. This will require that we open up our packaging, but I'm already looking at replacing the current packaging scripts used with using `jpackage` via Gradle or something. Until that happens, I hope this helps in testing FrostWire across multiple platforms! :smile: