### PR TITLE
[desktop] Make a distributable JAR file for Linux

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -231,8 +231,6 @@ sourceSets {
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-    archiveFileName = 'frostwire.jar'
-
     exclude('META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA', 'META-INF/*.MF', 'META-INF/*.md')
 
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }


### PR DESCRIPTION
This PR makes a few tweaks to the desktop project's Gradle file that makes the JAR filename a bit more presentable. It properly set's the project's version to `7.0-SNAPSHOT` and doesn't manually override the JAR file name. Thus, the JAR file name is now `frostwire-desktop-7.0-SNAPSHOT` rather than just `frostwire`.

Because jlibtorrent is now handled via Maven, it also appears that Gradle automatically handle's its native dependencies. In building a JAR via `./gradlew jar`, under `lib/x86_64`, we now have `libjlibtorrent-[version]-.so` (replace `[version]` with the proper jlibtorrent version). From testing the JAR file as built on Arch Linux, it runs perfectly.

Regarding issues such as having universal Linux distribution packaging, you may be interested in offering a JAR file as a kind of "universal Linux package". It might not be the best format, but I feel it's a good solution to have in the meantime until we figure out Flatpak or similar.