### PR TITLE
[desktop] Fix new desktop workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: "[Linux] Build JAR"
       if: runner.os != 'Windows' && runner.os != 'macOS'
-      run: ./gradlew jar
+      run: cd desktop && ./gradlew jar
 
     # Uncomment the following step to enable publishing builds when a release is made.
     #


### PR DESCRIPTION
Fixes the new desktop workflow I introduced by `cd`ing into the proper directory when building the JAR on Linux. Now the workflow should work properly! :tada:

I had also meant to force push my original branch in #1231, but unfortunately I forgot about the change I had on my laptop. Now that change is finally here! :sweat_smile: