### PR TITLE
[desktop] Update JMH plugin to 0.7.3

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -12,7 +12,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'me.champeau.jmh' version '0.7.2' /* JMH microbenchmarking framework */
+    id 'me.champeau.jmh' version '0.7.3' /* JMH microbenchmarking framework */
 }
 
 group = 'com.frostwire'


### PR DESCRIPTION
Just a simple update of the JMH plugin to 0.7.3. I'm not sure why we were using version 0.7.2 before, but I hope that upgrading to 0.7.3 doesn't cause any problems.