### PR TITLE
[desktop] Fix tray icon issues on Linux KDE Plasma (#845)

### DIFF
--- a/desktop/src/main/java/com/limegroup/gnutella/gui/Main.java
+++ b/desktop/src/main/java/com/limegroup/gnutella/gui/Main.java
@@ -50,6 +50,17 @@ public class Main {
      */
     public static void main(String[] args) {
         System.setProperty("sun.awt.noerasebackground", "true");
+        // On Linux/KDE, set the AWT application class name to "FrostWire" so that
+        // KDE Plasma shows "FrostWire" instead of "JavaEmbeddedFrame" in the system tray.
+        if (OSUtils.isLinux()) {
+            try {
+                var toolkit = Toolkit.getDefaultToolkit();
+                var field = toolkit.getClass().getDeclaredField("awtAppClassName");
+                field.setAccessible(true);
+                field.set(toolkit, "FrostWire");
+            } catch (Exception ignored) {
+            }
+        }
         String arch = System.getProperty("os.arch").toLowerCase();
         boolean isARM64 = arch.equals("aarch64") || arch.equals("arm64");	
 

--- a/desktop/src/main/java/com/limegroup/gnutella/gui/notify/TrayNotifier.java
+++ b/desktop/src/main/java/com/limegroup/gnutella/gui/notify/TrayNotifier.java
@@ -40,8 +40,8 @@ public final class TrayNotifier implements NotifyUser {
                 GUIMediator.getTrayMenu());
         _icon.addMouseListener(new MouseAdapter() {
             @Override
-            public void mousePressed(MouseEvent e) {
-                if ((e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) == MouseEvent.BUTTON1_DOWN_MASK) {
+            public void mouseClicked(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1) {
                     GUIMediator.restoreView();
                 }
             }


### PR DESCRIPTION
## Summary

Fixes #845 — the system tray icon on Linux KDE Plasma was non-functional (clicks ignored) and displayed "JavaEmbeddedFrame" instead of "FrostWire" as the tray label/tooltip.

## Root Cause

Java AWT's `SystemTray` uses the legacy X11 XEmbed protocol to embed tray icons. KDE Plasma uses the DBus-based StatusNotifierItem (SNI) protocol natively, with limited XEmbed backward compatibility. This mismatch caused two problems:

1. **Broken click handling** — `TrayNotifier` used `mousePressed` with `getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK` to detect left clicks. KDE's XEmbed tray implementation does not always deliver `mousePressed` events with the correct extended modifier flags, so the condition would fail silently and clicks were ignored.

2. **Wrong tray label** — KDE reads the X11 `WM_CLASS` property of the tray icon's embedded frame window to display the application name. Java AWT sets this to `"JavaEmbeddedFrame"` by default, so KDE shows that string instead of `"FrostWire"`.

## Changes

### `TrayNotifier.java` — Fix mouse click detection
- Replaced `mousePressed` → `mouseClicked`: fires after a complete press-release cycle, which is more reliably delivered by KDE's XEmbed bridge.
- Replaced `getModifiersEx() & BUTTON1_DOWN_MASK` → `getButton() == BUTTON1`: simpler, more portable check that doesn't depend on extended modifier state being correct at delivery time.

### `Main.java` — Fix X11 application class name on Linux
- At startup (before any AWT windows are created), sets `sun.awt.X11.XToolkit.awtAppClassName` to `"FrostWire"` via reflection on Linux.
- This causes the X11 `WM_CLASS` to be set to `"FrostWire"` for all AWT windows including the tray icon's embedded frame, so KDE displays the correct name.
- Wrapped in `try-catch` since this is an internal JDK field: it works on most OpenJDK builds, but may be inaccessible on JVMs with strict module encapsulation (would need `--add-opens java.desktop/sun.awt.X11=ALL-UNNAMED`). If it fails, behavior falls back to the current default — no regression.

## Additional Context

- The issue was originally filed in 2019 against Java 11 and older KDE. FrostWire now targets **Java 19**, and **KDE Plasma 5.20+** improved XEmbed tray support significantly. These code fixes address the remaining rough edges on top of the platform improvements.
- The `actionListener` on the `TrayIcon` (double-click restore) is left unchanged — it already works correctly.
- No changes to Windows or macOS behavior; the `awtAppClassName` fix is gated behind `OSUtils.isLinux()` and the click handling change is functionally equivalent on platforms that deliver mouse events correctly.

## Test plan

- [ ] Verify on **Linux KDE Plasma** (6.x or 5.27+): tray icon should show "FrostWire" label, left-click should restore the window, right-click should show the context menu (Restore / About / Exit)
- [ ] Verify on **Linux GNOME**: no regression — tray icon should work as before
- [ ] Verify on **Windows**: no regression — tray icon behavior unchanged
- [ ] Verify on **macOS**: no regression (tray icon not used on macOS, but confirm no startup errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)