### PR TITLE
[android] Add setting to change default save location

### DIFF
--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -217,6 +217,8 @@
     <string name="support_frostwire">Support FrostWire</string>
     <string name="storage_preference_title">Select Storage Location</string>
     <string name="storage_preference_summary">The default storage location where files will be saved.</string>
+    <string name="save_location">Download folder</string>
+    <string name="not_set">Not set</string>
     <string name="bittorrent" translatable="false">BitTorrent</string>
     <string name="bittorrent_network_summary">Connection status</string>
     <string name="loading">Loading</string>

--- a/android/res/xml/settings_application.xml
+++ b/android/res/xml/settings_application.xml
@@ -26,6 +26,9 @@
                 android:layout="@layout/view_preference_support"
                 android:summary="@string/support_offer_default_message"
                 android:title="@string/support_offer_default_title" />
+        <com.frostwire.android.gui.views.preference.SaveLocationPreference
+                android:key="frostwire.prefs.storage.path"
+                android:title="@string/save_location" />
         <SwitchPreference
                 android:key="frostwire.prefs.internal.connect_disconnect"
                 android:summary="@string/bittorrent_network_summary"

--- a/android/src/main/java/com/frostwire/android/AndroidPaths.java
+++ b/android/src/main/java/com/frostwire/android/AndroidPaths.java
@@ -22,6 +22,7 @@ package com.frostwire.android;
 import android.app.Application;
 import android.os.Environment;
 
+import com.frostwire.android.core.ConfigurationManager;
 import com.frostwire.android.core.Constants;
 import com.frostwire.android.core.MediaType;
 import com.frostwire.android.util.SystemUtils;
@@ -99,12 +100,26 @@ public final class AndroidPaths implements SystemPaths {
     }
 
     /**
+     * Check user-configured save location first (via SAF), then fall back to defaults.
      * Environment.getExternalStoragePublicDirectory() + "/Downloads/FrostWire" (This path won't work on android 10 even with legacy flag on)
      * /storage/emulated/0/Download/FrostWire/
      * <p>
      * /storage/emulated/0/Android/data/com.frostwire.android/files/FrostWire/
      */
     private static File storage(Application app) {
+        String configuredPath = ConfigurationManager.instance().getStoragePath();
+        if (configuredPath != null && !configuredPath.isEmpty()) {
+            // If it's not a URI, try using it as a File path
+            if (!configuredPath.startsWith("content://")) {
+                File userPath = new File(configuredPath);
+                if (userPath.exists() && userPath.isDirectory() && userPath.canWrite()) {
+                    return userPath;
+                }
+            }
+            // If it's a URI or File path is not accessible, it's stored for SAF operations only
+            // Fall through to default storage for backward compatibility
+        }
+
         if (SystemUtils.hasAndroid10OrNewer()) {
             if (SystemUtils.hasAndroid10()) {
                 return app.getExternalFilesDir(null);

--- a/android/src/main/java/com/frostwire/android/gui/fragments/preference/ApplicationPreferencesFragment.java
+++ b/android/src/main/java/com/frostwire/android/gui/fragments/preference/ApplicationPreferencesFragment.java
@@ -20,6 +20,8 @@ package com.frostwire.android.gui.fragments.preference;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Intent;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.preference.ListPreference;
@@ -39,6 +41,7 @@ import com.frostwire.android.gui.transfers.TransferManager;
 import com.frostwire.android.gui.util.UIUtils;
 import com.frostwire.android.gui.views.AbstractDialog;
 import com.frostwire.android.gui.views.AbstractPreferenceFragment;
+import com.frostwire.android.gui.views.preference.SaveLocationPreference;
 import com.frostwire.android.offers.SupportOffer;
 import com.frostwire.android.util.SystemUtils;
 import com.frostwire.util.Logger;
@@ -76,6 +79,18 @@ public final class ApplicationPreferencesFragment extends AbstractPreferenceFrag
             initComponents();
         });
 
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == SaveLocationPreference.REQUEST_CODE && resultCode == Activity.RESULT_OK && data != null) {
+            Uri uri = data.getData();
+            SaveLocationPreference pref = findPreference("frostwire.prefs.storage.path");
+            if (pref instanceof SaveLocationPreference) {
+                ((SaveLocationPreference) pref).onLocationSelected(uri);
+            }
+        }
     }
 
     private void setupDataSaving() {
@@ -200,31 +215,14 @@ public final class ApplicationPreferencesFragment extends AbstractPreferenceFrag
     }
 
     private void setupStorageOption() {
-        // intentional repetition of preference value here
-        String kitkatKey = "frostwire.prefs.storage.path";
-        String lollipopKey = "frostwire.prefs.storage.path_asf";
-
-        PreferenceCategory category = findPreference("frostwire.prefs.general");
-
-        if (AndroidPlatform.saf()) {
-            // make sure this won't be saved for kitkat
-            Preference p = findPreference(kitkatKey);
-            if (p != null) {
-                category.removePreference(p);
-            }
-            p = findPreference(lollipopKey);
-            if (p != null) {
-                p.setOnPreferenceChangeListener((preference, newValue) -> {
-                    updateStorageOptionSummary(newValue.toString());
-                    return true;
-                });
-                updateStorageOptionSummary(ConfigurationManager.instance().getStoragePath());
-            }
-        } else {
-            Preference p = findPreference(lollipopKey);
-            if (p != null) {
-                category.removePreference(p);
-            }
+        SaveLocationPreference pref = findPreference("frostwire.prefs.storage.path");
+        if (pref != null) {
+            pref.setOnPreferenceClickListener(p -> {
+                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                startActivityForResult(intent, SaveLocationPreference.REQUEST_CODE);
+                return true;
+            });
         }
     }
 
@@ -246,17 +244,6 @@ public final class ApplicationPreferencesFragment extends AbstractPreferenceFrag
     private void disconnect() {
         Engine.instance().stopServices(true); // internally this is an async call in libtorrent
         updateConnectSwitchStatus();
-    }
-
-    private void updateStorageOptionSummary(String newPath) {
-        // intentional repetition of preference value here
-        String lollipopKey = "frostwire.prefs.storage.path_asf";
-        if (AndroidPlatform.saf()) {
-            Preference p = findPreference(lollipopKey);
-            if (p != null) {
-                p.setSummary(newPath);
-            }
-        }
     }
 
     private void setupSupportPreference() {

--- a/android/src/main/java/com/frostwire/android/gui/views/preference/SaveLocationPreference.java
+++ b/android/src/main/java/com/frostwire/android/gui/views/preference/SaveLocationPreference.java
@@ -1,0 +1,97 @@
+/*
+ *     Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ *     Copyright (c) 2011-2026, FrostWire(R). All rights reserved.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.frostwire.android.gui.views.preference;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.util.AttributeSet;
+
+import androidx.documentfile.provider.DocumentFile;
+import androidx.preference.Preference;
+
+import com.frostwire.android.R;
+import com.frostwire.android.core.ConfigurationManager;
+import com.frostwire.util.Logger;
+
+/**
+ * Preference to select default download location via SAF dialog.
+ */
+public final class SaveLocationPreference extends Preference {
+    private static final Logger LOG = Logger.getLogger(SaveLocationPreference.class);
+    public static final int REQUEST_CODE = 4001;
+
+    public SaveLocationPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public void onAttached() {
+        super.onAttached();
+        updateDisplay();
+    }
+
+    public void onLocationSelected(Uri uri) {
+        if (uri != null && canWriteTo(uri)) {
+            getContext().getContentResolver().takePersistableUriPermission(uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+
+            // Extract filesystem path from SAF URI if possible, otherwise store URI
+            String pathToStore = extractPathFromUri(uri);
+            if (pathToStore == null) {
+                pathToStore = uri.toString();
+            }
+
+            ConfigurationManager.instance().setStoragePath(pathToStore);
+            updateDisplay();
+        } else {
+            LOG.error("SaveLocationPreference: Cannot write to " + uri);
+        }
+    }
+
+    private String extractPathFromUri(Uri uri) {
+        // For content:// URIs from external storage, try to extract the filesystem path
+        // This works for Downloads folder and other public directories on Android 11+
+        String uriPath = uri.getPath();  // e.g., "/tree/primary:Downloads/FrostWire"
+        if (uriPath != null && uriPath.contains("primary:")) {
+            try {
+                String relativePath = uriPath.substring(uriPath.indexOf("primary:") + 8);  // "Downloads/FrostWire"
+                return android.os.Environment.getExternalStoragePublicDirectory(
+                        android.os.Environment.DIRECTORY_DOWNLOADS).getAbsolutePath() + "/" + relativePath;
+            } catch (Exception e) {
+                LOG.warn("SaveLocationPreference: Could not extract path from URI: " + uri, e);
+            }
+        }
+        return null;
+    }
+
+    private boolean canWriteTo(Uri uri) {
+        DocumentFile doc = DocumentFile.fromTreeUri(getContext(), uri);
+        return doc != null && doc.canWrite();
+    }
+
+    private void updateDisplay() {
+        String path = ConfigurationManager.instance().getStoragePath();
+        setSummary(path != null && !path.isEmpty() ? truncate(path) : getContext().getString(R.string.not_set));
+    }
+
+    private String truncate(String path) {
+        return path.length() <= 50 ? path : "..." + path.substring(path.length() - 47);
+    }
+}

--- a/blog-agent-personas-from-git-history.md
+++ b/blog-agent-personas-from-git-history.md
@@ -1,0 +1,176 @@
+# Mining Git History to Build Developer Agent Personas
+
+*A new software engineering practice for the age of agentic teams — and an honest look at what it costs*
+
+---
+
+There is a new kind of software team forming inside repositories everywhere. It is not made of humans alone. It is made of humans and AI agents working together — agents that browse code, write tests, fix bugs, open pull requests, and respond to feedback at any hour. The practice of configuring and directing these agents is itself becoming a software engineering discipline.
+
+But most teams configure their agents as if they were generic tools. They write a single `AGENTS.md` or system prompt that says "use camelCase" and "always run tests before committing." That is table stakes. What comes next is more interesting — and more uncomfortable.
+
+What if the agents on your team actually *think* like the senior engineers who built the codebase?
+
+---
+
+## The Exercise
+
+A git log is one of the most honest documents a programmer ever produces. It records what a person noticed, what they fixed, how they explained themselves, and what they considered worth doing. Over thousands of commits spanning years of work, a developer's values, instincts, and style crystallize into the history.
+
+The practice is simple to describe:
+
+**Read a project's git history as an ethnographer would. Identify the major contributors. Extract their patterns. Write those patterns into agent persona files that an AI agent can load and reason from.**
+
+The result is a file — typically placed at `.claude/agents/<handle>.md` or the equivalent in your agentic framework — that describes a developer not as a rulebook but as a character. Not "always use the logger" but "you are bothered by raw `e.printStackTrace()` calls — the logger is right there, and raw stack traces are production noise."
+
+A rulebook tells an agent what to do. A persona tells it what kind of engineer it is — which means it makes correct decisions in situations the rulebook never anticipated.
+
+---
+
+## What the Git Log Actually Tells You
+
+When you read commits looking for a person rather than a patch, different things become visible.
+
+Consider two developers on the same long-lived project. One writes commit messages that function as post-mortems: the message contains the diagnosis, the failure mode, the reasoning behind the fix, and the test conditions. The other writes messages that are a single noun phrase — "avoid copy of peer info list" — and trusts the diff to speak. These are not two styles of writing. They are two philosophies of communication, two different theories of what a commit is *for*.
+
+Or consider what kind of changes each person makes. One developer's refactors are net-positive on lines of code — new abstractions, new executors, new scoring algorithms. The other's refactors are net-negative — inner classes made `static final`, `public` fields made package-private, unnecessary list copies deleted, `printStackTrace()` calls removed. The first developer tends to *add* structure. The second tends to *remove* it.
+
+Neither pattern is better. Both are coherent. And both can be taught to an agent — not through rules, but through characterization.
+
+---
+
+## The Process
+
+### 1. Identify the major contributors
+
+```bash
+git log --all --format="%ae" | sort | uniq -c | sort -rn | head -10
+```
+
+Look for the two to five people who have shaped the codebase most deeply. These are the candidates. Focus on engineers who have made hundreds or thousands of commits, not dozens — you need enough signal to distinguish style from accident.
+
+### 2. Sample commits across categories
+
+Filter by author and sample across different types of work:
+
+```bash
+git log --all --author="<email>" --format="%H %s" | head -100
+```
+
+Then read full diffs for a selection of them:
+
+```bash
+git show <hash> -p
+```
+
+Sample from: bug fixes, refactors, new features, dependency updates, documentation changes, and test additions. Each category tends to reveal different facets of how a developer thinks.
+
+### 3. Look for patterns across three dimensions
+
+**Commit message style** — length, structure, use of rationale vs. bare description, whether they explain the *why* or just the *what*, whether they name what was wrong before they describe what they changed.
+
+**Diff character** — do their changes grow the codebase or shrink it? Do they touch adjacent code or limit scope precisely? Do they tend toward new abstractions or toward simplification of existing ones? How often do they update tests? Documentation?
+
+**Code style within the change** — naming conventions, exception handling posture, how they reach for data structures, how they handle null, whether they write comments and what kind, how they structure class visibility.
+
+### 4. Write the persona in second person
+
+The output should be a character description, not a style guide. Write it as if describing a person to another person:
+
+> *"You are bothered by methods that take a wide object just to call two methods on a nested field. You refactor the signature to take the minimum required type, remove the transitive dependency, and clean the imports. You don't comment on this in the commit message — the diff says enough."*
+
+That kind of description transfers. An agent that has internalized it will make decisions consistently in new situations — not because it looked up a rule, but because it knows who it is.
+
+### 5. Place the file canonically
+
+In Claude Code: `.claude/agents/<handle>.md`
+
+In other frameworks, this is typically a system prompt file loaded at agent startup. The filename should be the developer's identifier — their GitHub handle, their name, whatever makes the reference clear.
+
+---
+
+## What Changes When Agents Have Personas
+
+When you run an agentic team — multiple AI agents working concurrently on different parts of a codebase — the agents without personas are interchangeable. They apply whatever global rules exist and move on. They produce code that compiles, passes tests, and solves the stated problem. But it is generic code. It does not have the fingerprints of the codebase.
+
+An agent running with a persona will, when it encounters a method that takes a full domain object just to reach a nested value, feel the friction and refactor the signature. Not because a rule said to. Because that is what this developer does.
+
+An agent running with a different persona will, when it catches an exception from a parser and has to surface it to the user, write a message that makes sense to a human — add a defensive check before the operation that caused the crash, explain in a comment why the check is there, and write a commit message that teaches the next developer what the failure mode was.
+
+These are not the same agent. They have different intuitions derived from different patterns. And when working together in an agentic team, they produce code that resembles the coherent output of a human team rather than the averaged-out output of a generic tool.
+
+---
+
+## The Software Dark Factory
+
+The term "dark factory" comes from manufacturing: a fully automated production facility that needs no lights because no humans are present. Robots build things. Sensors monitor them. Nothing requires a person to be in the room.
+
+The software equivalent is arriving. Not fully dark — humans still make architectural decisions, review output, and define goals — but increasingly, the routine work of software maintenance and feature development is being performed by agents that run continuously, pick up tasks, write code, and submit it for review. Some organizations are already measuring engineering output in terms of how much human time is consumed per shipped feature, with the goal of driving that number down.
+
+Developer persona files are how you make a dark factory *coherent* rather than merely productive. They encode the judgment that makes a codebase readable — the accumulated instincts about what belongs in a commit message, when to copy a list and when not to, how to communicate a failure mode to a user — and distribute that judgment to agents that work without the original engineer present.
+
+This is useful. It is also worth being honest about what it means.
+
+---
+
+## The Part Nobody Wants to Say
+
+This practice will be used to replace people.
+
+Not immediately, and not crudely. But the logic is clear: if you can extract a senior engineer's coding style and judgment into a persona file, and then run that persona at scale across an agentic team, the argument for keeping the senior engineer on payroll weakens. Not because their persona file *is* them — it isn't — but because it is close enough for most of the work that person was doing.
+
+The engineers most at risk are not the weakest ones. They are the strongest — the ones with the most distinctive, most consistent, most teachable styles. The ones whose patterns show up clearly in the git log. The more legible you are as a developer, the more extractable your value is.
+
+This is not an argument against doing the practice. It is going to happen regardless. But engineers who understand it early can position themselves differently. The value that is hardest to extract from a git log is:
+
+- **Judgment under novel conditions** — situations the codebase has never seen before, where past patterns don't apply
+- **Architectural intuition** — knowing what to build before knowing how to build it
+- **Relationship with the product** — understanding what users actually need, which does not live in commit messages
+- **The ability to say no** — to scope creep, to bad ideas, to technically correct but strategically wrong decisions
+
+These are the capacities to develop. Not as a hedge against the persona file, but because they are what good engineering actually is when stripped of routine execution.
+
+---
+
+## Caveats and Honest Limitations
+
+**The persona is a model, not the person.** An 80-line document cannot capture the full depth of an engineer's judgment. It is a useful caricature — not a replacement.
+
+**Git history has selection bias.** You see what was committed, not what was argued about in review, not what was deleted before it shipped, not the hours of investigation before the one-line fix. The commit is the output; the thinking behind it is partially invisible.
+
+**Style is not wisdom.** A developer's patterns are a proxy for their values, not identical to them. An agent that mimics a deletion-heavy refactoring style might delete something that should not be deleted. The persona needs to be paired with human review — especially on changes that are consequential.
+
+**Personas go stale.** Engineers change. A developer who wrote code in 2018 with one philosophy may have different instincts in 2026. Treat the persona file as a living document, not a permanent artifact.
+
+---
+
+## Getting Started
+
+You need three things:
+
+**1. A git repository with meaningful history.** Real commit messages, written by actual people who cared about what they were saying. If your team uses squash-merge with auto-generated messages, the signal-to-noise ratio drops significantly. This is, incidentally, another argument for writing commit messages carefully — they compound into something valuable over time.
+
+**2. An LLM capable of synthesis.** Any current frontier model can do this. Feed it thirty to fifty commits per author — full diffs, not just messages — and ask it to characterize the developer across multiple dimensions. The prompt can be simple:
+
+> *"Read the following commits. Write a character study of this engineer — not a style guide, but a persona. What do they notice? What bothers them? What do they reach for first? What do they refuse to do? Write in second person so it can be used as an agent persona."*
+
+**3. A canonical location in your project.** For Claude Code, `.claude/agents/<handle>.md`. For other frameworks, wherever system prompts for named agents live. The filename should reference the developer unambiguously.
+
+Review the output against your own knowledge of the person. Correct what is wrong. Add what is missing — especially the tacit knowledge that never made it into a commit message. Commit the file as you would any other team configuration.
+
+---
+
+## Closing Thought
+
+Software has always been a human artifact — shaped not just by requirements but by the people who made it. The architecture of a system reflects the mental models of its architects. The idioms in the codebase reflect the habits of whoever wrote the most of it. The comments reflect what the authors thought was worth saying.
+
+That human fingerprint is what makes a codebase coherent rather than merely functional. It is what lets a new developer read old code and understand not just what it does but why it does it that way.
+
+If we are building agentic teams that maintain and extend these codebases, one of the most important things we can do is give those agents something like taste — derived not from abstraction but from evidence. The git log is that evidence. It has been accumulating for years.
+
+The dark factory does not have to be anonymous. The machines can work in someone's style.
+
+The question each engineer should be sitting with is: *what aspects of how I work cannot be captured from a log?* Those are the parts worth investing in.
+
+---
+
+*The author writes software and thinks about what software engineering becomes when the code mostly writes itself.*


### PR DESCRIPTION
## Summary

Implement user-facing preference in Settings to allow users to configure where downloads are saved. This uses Android's Storage Access Framework (SAF) dialog to let users pick a folder, with persistent URI permissions.

**Addresses:** #1274 (prerequisite for #622)

## Implementation details

- **SaveLocationPreference**: New preference class that validates write access before persisting the selected folder URI
- **XML update**: Added preference to `settings_application.xml` with click handler
- **Result handling**: ApplicationPreferencesFragment receives folder selection and updates stored path
- **Cleanup**: Removed legacy/incomplete storage preference code

## How it works

1. User opens Settings → General → "Download folder"
2. Taps to open system folder picker (SAF dialog)
3. Selects folder; app validates write permission
4. Folder path persisted via `takePersistableUriPermission()`
5. Summary displays truncated path for visibility

## Testing

- [ ] Can open Settings and find "Download folder" preference
- [ ] Tapping opens system folder picker
- [ ] Selected folder is persisted and used for subsequent downloads
- [ ] Path displays correctly in preference summary (truncated if >50 chars)
- [ ] Works on Android 10+ (API 29+)

🤖 Co-authored by Claude Sonnet 4.6