### PR TITLE
Close FileInputStream in code

### DIFF
--- a/android/apollo/src/com/andrew/apollo/MusicPlaybackService.java
+++ b/android/apollo/src/com/andrew/apollo/MusicPlaybackService.java
@@ -2968,11 +2968,12 @@ public class MusicPlaybackService extends Service {
                     // /storage/emulated/0/Android/data/com.frostwire.android/files/FrostWire/TorrentData/...
                     try {
                         File f = new File(UrlUtils.decode(path));
-                        FileInputStream fis = new FileInputStream(f);
-                        player.setDataSource(fis.getFD());
-                    } catch (Throwable t) {
-                        LOG.info("MusicPlaybackService.setDataSource player.setDataSource(fileInputStream.getFD() failed -> " + t.getMessage(), true);
-                        player.setDataSource(path);
+                        try (FileInputStream fis = new FileInputStream(f)) {
+                            player.setDataSource(fis.getFD());
+                            } catch (Throwable t) {
+                            LOG.info("MusicPlaybackService.setDataSource player.setDataSource(fileInputStream.getFD() failed -> " + t.getMessage(), true);
+                            player.setDataSource(path);
+                        }
                     }
 
                 }


### PR DESCRIPTION
This in code only surfaces in the edge case, so may not be a priority. The resource opened there can leak if code exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.