### PR TITLE
Close InputStreamReader in readLines

### DIFF
--- a/common/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/common/src/main/java/org/apache/commons/io/IOUtils.java
@@ -902,8 +902,9 @@ public class IOUtils {
      * @since 2.3
      */
     public static List<String> readLines(InputStream input, Charset encoding) throws IOException {
-        InputStreamReader reader = new InputStreamReader(input, Charsets.toCharset(encoding));
-        return readLines(reader);
+        try (InputStreamReader reader = new InputStreamReader(input, Charsets.toCharset(encoding))) {
+            return readLines(reader);
+        }
     }
 
     /**


### PR DESCRIPTION
While tracing readLines in common/src/main/java/org/apache/commons/io/IOUtils.java I noticed what might be an issue: The resource opened there can leak if readLines exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Let me know if the approach doesn’t fit.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.