### PR TITLE
[android] Show disk-full error when a cloud download cannot be moved #622

### DIFF
--- a/android/src/main/java/com/frostwire/android/Android10QFileSystem.java
+++ b/android/src/main/java/com/frostwire/android/Android10QFileSystem.java
@@ -28,6 +28,8 @@ import com.frostwire.android.util.SystemUtils;
 import com.frostwire.platform.DefaultFileSystem;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class Android10QFileSystem extends DefaultFileSystem {
     private final Application app;
@@ -38,15 +40,18 @@ public class Android10QFileSystem extends DefaultFileSystem {
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
     public boolean copy(File src, File dest) {
-        lastCopyError = null;
+        lastCopyError.remove();
+        AtomicReference<Throwable> copyError = new AtomicReference<>();
         try {
-            boolean saved = Librarian.mediaStoreSaveToDownloads(src, dest, SystemUtils.hasAndroid10());
+            boolean saved = Librarian.mediaStoreSaveToDownloads(
+                    src, dest, SystemUtils.hasAndroid10(), copyError);
             if (!saved) {
-                lastCopyError = new java.io.IOException("MediaStore save failed for " + dest);
+                Throwable error = copyError.get();
+                lastCopyError.set(error != null ? error : new IOException("MediaStore save failed for " + dest));
             }
             return saved;
         } catch (Throwable e) {
-            lastCopyError = e;
+            lastCopyError.set(e);
             return false;
         }
     }

--- a/android/src/main/java/com/frostwire/android/Android10QFileSystem.java
+++ b/android/src/main/java/com/frostwire/android/Android10QFileSystem.java
@@ -38,6 +38,16 @@ public class Android10QFileSystem extends DefaultFileSystem {
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
     public boolean copy(File src, File dest) {
-        return Librarian.mediaStoreSaveToDownloads(src, dest, SystemUtils.hasAndroid10());
+        lastCopyError = null;
+        try {
+            boolean saved = Librarian.mediaStoreSaveToDownloads(src, dest, SystemUtils.hasAndroid10());
+            if (!saved) {
+                lastCopyError = new java.io.IOException("MediaStore save failed for " + dest);
+            }
+            return saved;
+        } catch (Throwable e) {
+            lastCopyError = e;
+            return false;
+        }
     }
 }

--- a/android/src/main/java/com/frostwire/android/LollipopFileSystem.java
+++ b/android/src/main/java/com/frostwire/android/LollipopFileSystem.java
@@ -68,6 +68,7 @@ public final class LollipopFileSystem implements FileSystem {
     private static final List<String> FIXED_SDCARD_PATHS = buildFixedSdCardPaths();
 
     private final Application app;
+    private volatile Throwable lastCopyError;
 
     public LollipopFileSystem(Application app) {
         this.app = app;
@@ -219,12 +220,18 @@ public final class LollipopFileSystem implements FileSystem {
     }
 
     @Override
+    public Throwable lastCopyError() {
+        return lastCopyError;
+    }
+
+    @Override
     public boolean copy(File src, File dest) {
+        lastCopyError = null;
         try {
             FileUtils.copyFile(src, dest);
             return true;
         } catch (Throwable e) {
-            // ignore
+            lastCopyError = e;
             LOG.error(e.getMessage(), e);
         }
 
@@ -233,15 +240,21 @@ public final class LollipopFileSystem implements FileSystem {
 
         if (srcF == null) {
             LOG.error("Unable to obtain document for file: " + src);
+            if (lastCopyError == null) {
+                lastCopyError = new IOException("Unable to obtain document for file: " + src);
+            }
             return false;
         }
 
         if (destF == null) {
             LOG.error("Unable to obtain or create document for file: " + dest);
+            if (lastCopyError == null) {
+                lastCopyError = new IOException("Unable to obtain or create document for file: " + dest);
+            }
             return false;
         }
 
-        return copy(app, srcF, destF);
+        return copyDocuments(app, srcF, destF);
     }
 
     @Override
@@ -684,7 +697,7 @@ public final class LollipopFileSystem implements FileSystem {
 
     //------------ more tools methods
 
-    private static boolean copy(Context context, DocumentFile source, DocumentFile target) {
+    private boolean copyDocuments(Context context, DocumentFile source, DocumentFile target) {
         InputStream inStream = null;
         OutputStream outStream = null;
         try {
@@ -698,6 +711,7 @@ public final class LollipopFileSystem implements FileSystem {
             }
 
         } catch (Throwable e) {
+            lastCopyError = e;
             LOG.error("Error when copying file from " + source.getUri() + " to " + target.getUri(), e);
             return false;
         } finally {

--- a/android/src/main/java/com/frostwire/android/LollipopFileSystem.java
+++ b/android/src/main/java/com/frostwire/android/LollipopFileSystem.java
@@ -68,7 +68,7 @@ public final class LollipopFileSystem implements FileSystem {
     private static final List<String> FIXED_SDCARD_PATHS = buildFixedSdCardPaths();
 
     private final Application app;
-    private volatile Throwable lastCopyError;
+    private final ThreadLocal<Throwable> lastCopyError = new ThreadLocal<>();
 
     public LollipopFileSystem(Application app) {
         this.app = app;
@@ -221,17 +221,17 @@ public final class LollipopFileSystem implements FileSystem {
 
     @Override
     public Throwable lastCopyError() {
-        return lastCopyError;
+        return lastCopyError.get();
     }
 
     @Override
     public boolean copy(File src, File dest) {
-        lastCopyError = null;
+        lastCopyError.remove();
         try {
             FileUtils.copyFile(src, dest);
             return true;
         } catch (Throwable e) {
-            lastCopyError = e;
+            lastCopyError.set(e);
             LOG.error(e.getMessage(), e);
         }
 
@@ -240,16 +240,16 @@ public final class LollipopFileSystem implements FileSystem {
 
         if (srcF == null) {
             LOG.error("Unable to obtain document for file: " + src);
-            if (lastCopyError == null) {
-                lastCopyError = new IOException("Unable to obtain document for file: " + src);
+            if (lastCopyError.get() == null) {
+                lastCopyError.set(new IOException("Unable to obtain document for file: " + src));
             }
             return false;
         }
 
         if (destF == null) {
             LOG.error("Unable to obtain or create document for file: " + dest);
-            if (lastCopyError == null) {
-                lastCopyError = new IOException("Unable to obtain or create document for file: " + dest);
+            if (lastCopyError.get() == null) {
+                lastCopyError.set(new IOException("Unable to obtain or create document for file: " + dest));
             }
             return false;
         }
@@ -711,7 +711,7 @@ public final class LollipopFileSystem implements FileSystem {
             }
 
         } catch (Throwable e) {
-            lastCopyError = e;
+            lastCopyError.set(e);
             LOG.error("Error when copying file from " + source.getUri() + " to " + target.getUri(), e);
             return false;
         } finally {

--- a/android/src/main/java/com/frostwire/android/gui/Librarian.java
+++ b/android/src/main/java/com/frostwire/android/gui/Librarian.java
@@ -57,6 +57,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,6 +65,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
+import java.util.concurrent.atomic.AtomicReference;
 
 import okio.BufferedSink;
 import okio.Okio;
@@ -420,11 +422,19 @@ public final class Librarian {
      */
     @RequiresApi(api = Build.VERSION_CODES.Q)
     public static boolean mediaStoreSaveToDownloads(File src, File destInDownloads, boolean copyBytesToMediaStore) {
+        return mediaStoreSaveToDownloads(src, destInDownloads, copyBytesToMediaStore, null);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.Q)
+    public static boolean mediaStoreSaveToDownloads(File src, File destInDownloads,
+                                                    boolean copyBytesToMediaStore,
+                                                    AtomicReference<Throwable> error) {
         LOG.info("Librarian::mediaStoreSaveToDownloads trying to save " + src.getAbsolutePath() + " into " + destInDownloads.getAbsolutePath());
 
         Context context = SystemUtils.getApplicationContext();
         if (context == null) {
             LOG.info("Librarian::mediaStoreSaveToDownloads aborting. ApplicationContext reference is null, not ready yet.");
+            setCopyError(error, new IOException("Application context is unavailable"));
             return false;
         }
 
@@ -432,10 +442,17 @@ public final class Librarian {
 
         if (Librarian.mediaStoreFileExists(destInDownloads)) {
             LOG.info("Librarian::mediaStoreSaveToDownloads aborting. " + relativePath + "/" + destInDownloads.getName() + " already exists on the media store db");
+            setCopyError(error, new IOException("MediaStore destination already exists: " + destInDownloads));
             return false;
         }
 
-        return mediaStoreInsert(context, src, relativePath, copyBytesToMediaStore);
+        return mediaStoreInsert(context, src, relativePath, copyBytesToMediaStore, error);
+    }
+
+    private static void setCopyError(AtomicReference<Throwable> error, Throwable value) {
+        if (error != null) {
+            error.set(value);
+        }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
@@ -459,8 +476,11 @@ public final class Librarian {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
-    private static boolean mediaStoreInsert(Context context, File srcFile, String relativeFolderPath, boolean copyBytesToMediaStore) {
+    private static boolean mediaStoreInsert(Context context, File srcFile, String relativeFolderPath,
+                                            boolean copyBytesToMediaStore,
+                                            AtomicReference<Throwable> error) {
         if (srcFile.isDirectory()) {
+            setCopyError(error, new IOException("MediaStore source is a directory: " + srcFile));
             return false;
         }
         // Add to MediaStore
@@ -526,13 +546,15 @@ public final class Librarian {
             Uri insertedUri = resolver.insert(downloadsExternalUri, values);
             if (insertedUri == null) {
                 LOG.error("mediaStoreInsert -> could not perform media store insertion");
+                setCopyError(error, new IOException("MediaStore insertion returned null"));
                 return false;
             }
             LOG.info("mediaStoreInsert -> insertedUri = " + insertedUri);
             if (copyBytesToMediaStore) {
-                return copyFileBytesToMediaStore(resolver, srcFile, values, insertedUri);
+                return copyFileBytesToMediaStore(resolver, srcFile, values, insertedUri, error);
             }
         } catch (Throwable t) {
+            setCopyError(error, t);
             return false;
         }
         return true;
@@ -540,9 +562,10 @@ public final class Librarian {
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
     private static boolean copyFileBytesToMediaStore(ContentResolver contentResolver,
-                                                     File srcFile,
-                                                     ContentValues values,
-                                                     Uri insertedUri) {
+                                                      File srcFile,
+                                                      ContentValues values,
+                                                      Uri insertedUri,
+                                                      AtomicReference<Throwable> error) {
         try {
             OutputStream outputStream = contentResolver.openOutputStream(insertedUri);
             if (outputStream == null) {
@@ -555,6 +578,7 @@ public final class Librarian {
             sink.close();
         } catch (Throwable t) {
             LOG.error("Librarian::copyFileBytesToMediaStore error: " + t.getMessage(), t);
+            setCopyError(error, t);
             return false;
         }
         values.clear();

--- a/android/src/test/java/com/frostwire/transfers/HttpDownloadDiskFullTest.java
+++ b/android/src/test/java/com/frostwire/transfers/HttpDownloadDiskFullTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -66,7 +68,15 @@ public class HttpDownloadDiskFullTest {
     };
     for (Path file : candidates) {
       if (Files.isRegularFile(file)) {
-        return Files.readString(file, StandardCharsets.UTF_8);
+        try (FileInputStream input = new FileInputStream(file.toFile());
+             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+          byte[] buffer = new byte[4096];
+          int count;
+          while ((count = input.read(buffer)) != -1) {
+            output.write(buffer, 0, count);
+          }
+          return output.toString(StandardCharsets.UTF_8.name());
+        }
       }
     }
     throw new IOException("missing " + relativePath + " from " + cwd);

--- a/android/src/test/java/com/frostwire/transfers/HttpDownloadDiskFullTest.java
+++ b/android/src/test/java/com/frostwire/transfers/HttpDownloadDiskFullTest.java
@@ -1,0 +1,74 @@
+/*
+ *     Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ *     Copyright (c) 2011-2026, FrostWire(R). All rights reserved.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.frostwire.transfers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+
+public class HttpDownloadDiskFullTest {
+
+  @Test
+  public void noSpaceLeftIsDiskFullAndSafFailureIsNot() {
+    assertEquals(
+        TransferState.ERROR_DISK_FULL,
+        BaseHttpDownload.downloadErrorState(new IOException("No space left on device")));
+    assertEquals(
+        TransferState.ERROR_DISK_FULL,
+        BaseHttpDownload.failedMoveState(new IOException("No space left on device")));
+    assertEquals(TransferState.ERROR_MOVING_INCOMPLETE, BaseHttpDownload.failedMoveState(null));
+    assertEquals(
+        TransferState.ERROR_MOVING_INCOMPLETE,
+        BaseHttpDownload.failedMoveState(new IOException("Permission denied")));
+    assertEquals(
+        TransferState.ERROR_MOVING_INCOMPLETE,
+        BaseHttpDownload.failedMoveState(
+            new IOException(
+                "Unable to obtain document for file: content://com.android.externalstorage.documents/tree/primary%3ADownload/track.mp3")));
+  }
+
+  @Test
+  public void moveAndCompleteDoesNotInferDiskFullFromUsableSpace() throws Exception {
+    String source = readCommon("src/main/java/com/frostwire/transfers/BaseHttpDownload.java");
+    assertFalse(source.contains("getUsableSpace"));
+    assertTrue(source.contains("failedMoveState(fs.lastCopyError())"));
+    assertTrue(source.contains("isNoSpaceLeft"));
+  }
+
+  private static String readCommon(String relativePath) throws Exception {
+    Path cwd = Path.of(System.getProperty("user.dir"));
+    Path[] candidates = {
+      cwd.resolve("..").resolve("common").resolve(relativePath),
+      cwd.resolve("common").resolve(relativePath),
+      cwd.getParent().resolve("common").resolve(relativePath)
+    };
+    for (Path file : candidates) {
+      if (Files.isRegularFile(file)) {
+        return Files.readString(file, StandardCharsets.UTF_8);
+      }
+    }
+    throw new IOException("missing " + relativePath + " from " + cwd);
+  }
+}

--- a/common/src/main/java/com/frostwire/platform/DefaultFileSystem.java
+++ b/common/src/main/java/com/frostwire/platform/DefaultFileSystem.java
@@ -32,7 +32,7 @@ import java.util.LinkedList;
  */
 public class DefaultFileSystem implements FileSystem {
     private static final Logger LOG = Logger.getLogger(DefaultFileSystem.class);
-    protected volatile Throwable lastCopyError;
+    protected final ThreadLocal<Throwable> lastCopyError = new ThreadLocal<>();
 
     public static void walkFiles(FileSystem fs, File file, FileFilter filter) {
         File[] arr = fs.listFiles(file, filter);
@@ -106,13 +106,13 @@ public class DefaultFileSystem implements FileSystem {
 
     @Override
     public boolean copy(File src, File dest) {
-        lastCopyError = null;
+        lastCopyError.remove();
         try {
             FileUtils.copyFile(src, dest);
             LOG.info("Success: DefaultFileSystem.copy(src=" + src + ", dest=" + dest + ")");
             return true;
         } catch (Throwable e) {
-            lastCopyError = e;
+            lastCopyError.set(e);
             LOG.error("Error in copy file: " + src + " -> " + dest, e);
         }
         return false;
@@ -120,7 +120,7 @@ public class DefaultFileSystem implements FileSystem {
 
     @Override
     public Throwable lastCopyError() {
-        return lastCopyError;
+        return lastCopyError.get();
     }
 
     @Override

--- a/common/src/main/java/com/frostwire/platform/DefaultFileSystem.java
+++ b/common/src/main/java/com/frostwire/platform/DefaultFileSystem.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
  */
 public class DefaultFileSystem implements FileSystem {
     private static final Logger LOG = Logger.getLogger(DefaultFileSystem.class);
+    protected volatile Throwable lastCopyError;
 
     public static void walkFiles(FileSystem fs, File file, FileFilter filter) {
         File[] arr = fs.listFiles(file, filter);
@@ -105,14 +106,21 @@ public class DefaultFileSystem implements FileSystem {
 
     @Override
     public boolean copy(File src, File dest) {
+        lastCopyError = null;
         try {
             FileUtils.copyFile(src, dest);
             LOG.info("Success: DefaultFileSystem.copy(src=" + src + ", dest=" + dest + ")");
             return true;
         } catch (Throwable e) {
+            lastCopyError = e;
             LOG.error("Error in copy file: " + src + " -> " + dest, e);
         }
         return false;
+    }
+
+    @Override
+    public Throwable lastCopyError() {
+        return lastCopyError;
     }
 
     @Override

--- a/common/src/main/java/com/frostwire/platform/FileSystem.java
+++ b/common/src/main/java/com/frostwire/platform/FileSystem.java
@@ -47,6 +47,10 @@ public interface FileSystem {
 
     boolean copy(File src, File dest);
 
+    default Throwable lastCopyError() {
+        return null;
+    }
+
     boolean write(File file, byte[] data);
 
     void walk(File file, FileFilter filter);

--- a/common/src/main/java/com/frostwire/transfers/BaseHttpDownload.java
+++ b/common/src/main/java/com/frostwire/transfers/BaseHttpDownload.java
@@ -325,8 +325,19 @@ public abstract class BaseHttpDownload implements Transfer {
         }
     }
 
+    static boolean isNoSpaceLeft(Throwable e) {
+        while (e != null) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("No space left on device")) {
+                return true;
+            }
+            e = e.getCause();
+        }
+        return false;
+    }
+
     static TransferState downloadErrorState(Throwable e) {
-        if (e.getMessage() != null && e.getMessage().contains("No space left on device")) {
+        if (isNoSpaceLeft(e)) {
             return TransferState.ERROR_DISK_FULL;
         }
         if (e instanceof SSLException || e instanceof SocketTimeoutException) {
@@ -359,23 +370,15 @@ public abstract class BaseHttpDownload implements Transfer {
             state = TransferState.SCANNING;
             complete(TransferState.COMPLETE);
         } else {
-            complete(failedMoveState(src.length(), usableSpaceFor(dst)));
+            complete(failedMoveState(fs.lastCopyError()));
         }
     }
 
-    static TransferState failedMoveState(long bytesNeeded, long usableSpace) {
-        if (usableSpace >= 0 && usableSpace < bytesNeeded) {
+    static TransferState failedMoveState(Throwable copyError) {
+        if (isNoSpaceLeft(copyError)) {
             return TransferState.ERROR_DISK_FULL;
         }
         return TransferState.ERROR_MOVING_INCOMPLETE;
-    }
-
-    static long usableSpaceFor(File dest) {
-        File dir = dest.getParentFile();
-        if (dir == null || !dir.isDirectory()) {
-            return Long.MAX_VALUE;
-        }
-        return dir.getUsableSpace();
     }
 
     protected void onHttpComplete() {

--- a/common/src/main/java/com/frostwire/transfers/BaseHttpDownload.java
+++ b/common/src/main/java/com/frostwire/transfers/BaseHttpDownload.java
@@ -320,18 +320,22 @@ public abstract class BaseHttpDownload implements Transfer {
 
     protected final void error(Throwable e) {
         if (state != TransferState.CANCELED) {
-            complete(TransferState.ERROR);
             LOG.error("General error in download " + info, e);
-            if (e.getMessage() != null && e.getMessage().contains("No space left on device")) {
-                complete(TransferState.ERROR_DISK_FULL);
-            }
-            if (e instanceof SSLException || e instanceof SocketTimeoutException) {
-                complete(TransferState.ERROR_CONNECTION_TIMED_OUT);
-            }
-            if (e instanceof UnknownHostException) {
-                complete(TransferState.ERROR_NO_INTERNET);
-            }
+            complete(downloadErrorState(e));
         }
+    }
+
+    static TransferState downloadErrorState(Throwable e) {
+        if (e.getMessage() != null && e.getMessage().contains("No space left on device")) {
+            return TransferState.ERROR_DISK_FULL;
+        }
+        if (e instanceof SSLException || e instanceof SocketTimeoutException) {
+            return TransferState.ERROR_CONNECTION_TIMED_OUT;
+        }
+        if (e instanceof UnknownHostException) {
+            return TransferState.ERROR_NO_INTERNET;
+        }
+        return TransferState.ERROR;
     }
 
     protected void moveAndComplete(File src, File dst) {
@@ -355,8 +359,23 @@ public abstract class BaseHttpDownload implements Transfer {
             state = TransferState.SCANNING;
             complete(TransferState.COMPLETE);
         } else {
-            complete(TransferState.ERROR_MOVING_INCOMPLETE);
+            complete(failedMoveState(src.length(), usableSpaceFor(dst)));
         }
+    }
+
+    static TransferState failedMoveState(long bytesNeeded, long usableSpace) {
+        if (usableSpace >= 0 && usableSpace < bytesNeeded) {
+            return TransferState.ERROR_DISK_FULL;
+        }
+        return TransferState.ERROR_MOVING_INCOMPLETE;
+    }
+
+    static long usableSpaceFor(File dest) {
+        File dir = dest.getParentFile();
+        if (dir == null || !dir.isDirectory()) {
+            return Long.MAX_VALUE;
+        }
+        return dir.getUsableSpace();
     }
 
     protected void onHttpComplete() {

--- a/common/src/test/java/com/frostwire/platform/DefaultFileSystemCopyErrorThreadSafetyTest.java
+++ b/common/src/test/java/com/frostwire/platform/DefaultFileSystemCopyErrorThreadSafetyTest.java
@@ -1,0 +1,79 @@
+/*
+ *     Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ *     Copyright (c) 2011-2026, FrostWire(R). All rights reserved.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.frostwire.platform;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class DefaultFileSystemCopyErrorThreadSafetyTest {
+
+    @Test
+    void copyErrorsRemainBoundToTheCopyingThread() throws Exception {
+        TestFileSystem fs = new TestFileSystem();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicReference<Throwable> firstResult = new AtomicReference<>();
+        AtomicReference<Throwable> secondResult = new AtomicReference<>();
+        IOException firstError = new IOException("first");
+        IOException secondError = new IOException("second");
+
+        Thread first = new Thread(() -> {
+            fs.setCopyError(firstError);
+            ready.countDown();
+            await(release);
+            firstResult.set(fs.lastCopyError());
+        });
+        Thread second = new Thread(() -> {
+            fs.setCopyError(secondError);
+            ready.countDown();
+            await(release);
+            secondResult.set(fs.lastCopyError());
+        });
+
+        first.start();
+        second.start();
+        ready.await();
+        release.countDown();
+        first.join();
+        second.join();
+
+        assertSame(firstError, firstResult.get());
+        assertSame(secondError, secondResult.get());
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+
+    private static final class TestFileSystem extends DefaultFileSystem {
+        void setCopyError(Throwable error) {
+            lastCopyError.set(error);
+        }
+    }
+}

--- a/common/src/test/java/com/frostwire/transfers/BaseHttpDownloadDiskFullTest.java
+++ b/common/src/test/java/com/frostwire/transfers/BaseHttpDownloadDiskFullTest.java
@@ -1,0 +1,65 @@
+/*
+ *     Created by Angel Leon (@gubatron), Alden Torres (aldenml)
+ *     Copyright (c) 2011-2026, FrostWire(R). All rights reserved.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.frostwire.transfers;
+
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BaseHttpDownloadDiskFullTest {
+
+    @Test
+    public void downloadErrorMapsNoSpaceLeftToDiskFull() {
+        assertEquals(TransferState.ERROR_DISK_FULL,
+                BaseHttpDownload.downloadErrorState(new IOException("No space left on device")));
+    }
+
+    @Test
+    public void downloadErrorKeepsGenericError() {
+        assertEquals(TransferState.ERROR,
+                BaseHttpDownload.downloadErrorState(new IOException("broken pipe")));
+    }
+
+    @Test
+    public void downloadErrorMapsTimeoutAndUnknownHost() {
+        assertEquals(TransferState.ERROR_CONNECTION_TIMED_OUT,
+                BaseHttpDownload.downloadErrorState(new SocketTimeoutException("read timed out")));
+        assertEquals(TransferState.ERROR_CONNECTION_TIMED_OUT,
+                BaseHttpDownload.downloadErrorState(new SSLException("handshake")));
+        assertEquals(TransferState.ERROR_NO_INTERNET,
+                BaseHttpDownload.downloadErrorState(new UnknownHostException("example.invalid")));
+    }
+
+    @Test
+    public void failedMoveUsesDiskFullWhenDestinationHasLessSpaceThanTheFile() {
+        assertEquals(TransferState.ERROR_DISK_FULL,
+                BaseHttpDownload.failedMoveState(1024, 16));
+    }
+
+    @Test
+    public void failedMoveKeepsMovingIncompleteWhenThereIsSpace() {
+        assertEquals(TransferState.ERROR_MOVING_INCOMPLETE,
+                BaseHttpDownload.failedMoveState(1024, 4096));
+    }
+}

--- a/common/src/test/java/com/frostwire/transfers/BaseHttpDownloadDiskFullTest.java
+++ b/common/src/test/java/com/frostwire/transfers/BaseHttpDownloadDiskFullTest.java
@@ -18,14 +18,22 @@
 
 package com.frostwire.transfers;
 
+import com.frostwire.platform.DefaultFileSystem;
+import com.frostwire.transfers.BaseHttpDownload;
+import com.frostwire.transfers.TransferState;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLException;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class BaseHttpDownloadDiskFullTest {
 
@@ -33,6 +41,9 @@ public class BaseHttpDownloadDiskFullTest {
     public void downloadErrorMapsNoSpaceLeftToDiskFull() {
         assertEquals(TransferState.ERROR_DISK_FULL,
                 BaseHttpDownload.downloadErrorState(new IOException("No space left on device")));
+        assertEquals(TransferState.ERROR_DISK_FULL,
+                BaseHttpDownload.downloadErrorState(new IOException("copy failed",
+                        new IOException("No space left on device"))));
     }
 
     @Test
@@ -52,14 +63,42 @@ public class BaseHttpDownloadDiskFullTest {
     }
 
     @Test
-    public void failedMoveUsesDiskFullWhenDestinationHasLessSpaceThanTheFile() {
+    public void failedMoveUsesDiskFullOnlyForNoSpaceLeft() {
         assertEquals(TransferState.ERROR_DISK_FULL,
-                BaseHttpDownload.failedMoveState(1024, 16));
+                BaseHttpDownload.failedMoveState(new IOException("No space left on device")));
+        assertEquals(TransferState.ERROR_MOVING_INCOMPLETE,
+                BaseHttpDownload.failedMoveState(new IOException("Permission denied")));
+        assertEquals(TransferState.ERROR_MOVING_INCOMPLETE,
+                BaseHttpDownload.failedMoveState(new IOException("Read-only file system")));
     }
 
     @Test
-    public void failedMoveKeepsMovingIncompleteWhenThereIsSpace() {
+    public void safStyleCopyFailureWithoutIoExceptionStaysMovingIncomplete() {
+        // DocumentFile copy often returns false with no Java ENOSPC.
         assertEquals(TransferState.ERROR_MOVING_INCOMPLETE,
-                BaseHttpDownload.failedMoveState(1024, 4096));
+                BaseHttpDownload.failedMoveState(null));
+        assertEquals(TransferState.ERROR_MOVING_INCOMPLETE,
+                BaseHttpDownload.failedMoveState(new IOException(
+                        "Unable to obtain document for file: /storage/0000-0000/Music/track.mp3")));
+    }
+
+    @Test
+    public void defaultFileSystemCopyFailureIsNotReportedAsDiskFull() throws Exception {
+        DefaultFileSystem fs = new DefaultFileSystem();
+        File src = File.createTempFile("fw-src", ".bin");
+        try (FileOutputStream out = new FileOutputStream(src)) {
+            out.write("payload".getBytes(StandardCharsets.UTF_8));
+        }
+        File notADir = File.createTempFile("fw-notdir", ".bin");
+        File dest = new File(notADir, "child.bin");
+        try {
+            assertFalse(fs.copy(src, dest));
+            assertNotNull(fs.lastCopyError());
+            assertEquals(TransferState.ERROR_MOVING_INCOMPLETE,
+                    BaseHttpDownload.failedMoveState(fs.lastCopyError()));
+        } finally {
+            src.delete();
+            notADir.delete();
+        }
     }
 }

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -488,6 +488,7 @@ test {
         includeTestsMatching "com.frostwire.util.*"
         includeTestsMatching "com.frostwire.mp4.*"
         includeTestsMatching "com.frostwire.platform.*"
+        includeTestsMatching "com.frostwire.transfers.*"
         includeTestsMatching "com.frostwire.search.*"
         includeTestsMatching "com.frostwire.util.*"
         includeTestsMatching "com.frostwire.tests.*"


### PR DESCRIPTION
Cloud/HTTP transfers were showing Error moving incomplete (YouTube/SoundCloud) or a generic Error (Archive.org) when the destination had no space left. Torrents already map that to the no-space-left string.

I pick ERROR_DISK_FULL before notifying if the download fails with No space left on device, and I use the same state when a completed temp file cannot be moved because the destination has less free space than the file.

#622